### PR TITLE
Created a unified message package and refactored

### DIFF
--- a/broker/cluster/events.go
+++ b/broker/cluster/events.go
@@ -18,7 +18,7 @@ import (
 	"bytes"
 	"encoding/binary"
 
-	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/collection"
 	"github.com/emitter-io/emitter/security"
 	"github.com/emitter-io/emitter/utils"
@@ -27,9 +27,9 @@ import (
 
 // SubscriptionEvent represents a subscription event.
 type SubscriptionEvent struct {
-	Ssid subscription.Ssid // The SSID for the subscription.
-	Peer mesh.PeerName     // The name of the peer.
-	Conn security.ID       // The connection identifier.
+	Ssid message.Ssid  // The SSID for the subscription.
+	Peer mesh.PeerName // The name of the peer.
+	Conn security.ID   // The connection identifier.
 }
 
 // Encode encodes the event to string representation.

--- a/broker/cluster/events.go
+++ b/broker/cluster/events.go
@@ -22,42 +22,8 @@ import (
 	"github.com/emitter-io/emitter/collection"
 	"github.com/emitter-io/emitter/security"
 	"github.com/emitter-io/emitter/utils"
-	"github.com/golang/snappy"
 	"github.com/weaveworks/mesh"
 )
-
-// MessageFrame represents a message frame which is sent through the wire to the
-// remote server and contains a set of messages
-type MessageFrame []Message
-
-// Message represents a message which has to be routed.
-type Message struct {
-	Ssid    subscription.Ssid // The Ssid of the message
-	Channel []byte            // The channel of the message
-	Payload []byte            // The payload of the message
-}
-
-// Encode encodes the message frame
-func (f *MessageFrame) Encode() (out []byte, err error) {
-	// TODO: optimize
-	var enc []byte
-	if enc, err = utils.Encode(f); err == nil {
-		out = snappy.Encode(out, enc)
-		return
-	}
-	return
-}
-
-// decodeMessageFrame decodes the message frame from the decoder.
-func decodeMessageFrame(buf []byte) (out MessageFrame, err error) {
-	// TODO: optimize
-	var buffer []byte
-	if buf, err = snappy.Decode(buffer, buf); err == nil {
-		out = make(MessageFrame, 0, 64)
-		err = utils.Decode(buf, &out)
-	}
-	return
-}
 
 // SubscriptionEvent represents a subscription event.
 type SubscriptionEvent struct {

--- a/broker/cluster/events.go
+++ b/broker/cluster/events.go
@@ -20,8 +20,8 @@ import (
 
 	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/collection"
-	"github.com/emitter-io/emitter/encoding"
 	"github.com/emitter-io/emitter/security"
+	"github.com/emitter-io/emitter/utils"
 	"github.com/golang/snappy"
 	"github.com/weaveworks/mesh"
 )
@@ -41,7 +41,7 @@ type Message struct {
 func (f *MessageFrame) Encode() (out []byte, err error) {
 	// TODO: optimize
 	var enc []byte
-	if enc, err = encoding.Encode(f); err == nil {
+	if enc, err = utils.Encode(f); err == nil {
 		out = snappy.Encode(out, enc)
 		return
 	}
@@ -54,7 +54,7 @@ func decodeMessageFrame(buf []byte) (out MessageFrame, err error) {
 	var buffer []byte
 	if buf, err = snappy.Decode(buffer, buf); err == nil {
 		out = make(MessageFrame, 0, 64)
-		err = encoding.Decode(buf, &out)
+		err = utils.Decode(buf, &out)
 	}
 	return
 }
@@ -128,7 +128,7 @@ func newSubscriptionState() *subscriptionState {
 // decodeSubscriptionState decodes the state
 func decodeSubscriptionState(buf []byte) (*subscriptionState, error) {
 	var out collection.LWWState
-	err := encoding.Decode(buf, &out)
+	err := utils.Decode(buf, &out)
 	return &subscriptionState{Set: out}, err
 }
 
@@ -138,7 +138,7 @@ func (st *subscriptionState) Encode() [][]byte {
 	lww.Lock()
 	defer lww.Unlock()
 
-	buf, err := encoding.Encode(lww.Set)
+	buf, err := utils.Encode(lww.Set)
 	if err != nil {
 		panic(err)
 	}

--- a/broker/cluster/events_test.go
+++ b/broker/cluster/events_test.go
@@ -3,7 +3,7 @@ package cluster
 import (
 	"testing"
 
-	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/collection"
 	"github.com/stretchr/testify/assert"
 )
@@ -25,7 +25,7 @@ func TestEncodeSubscriptionState(t *testing.T) {
 
 func TestEncodeSubscriptionEvent(t *testing.T) {
 	ev := SubscriptionEvent{
-		Ssid: subscription.Ssid{1, 2, 3, 4, 5},
+		Ssid: message.Ssid{1, 2, 3, 4, 5},
 		Peer: 657,
 		Conn: 12456,
 	}

--- a/broker/cluster/events_test.go
+++ b/broker/cluster/events_test.go
@@ -8,22 +8,6 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_decodeMessageFrame(t *testing.T) {
-	frame := MessageFrame{
-		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
-		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
-	}
-
-	// Encode
-	buffer, err := frame.Encode()
-	assert.NoError(t, err)
-
-	// Decode
-	output, err := decodeMessageFrame(buffer)
-	assert.NoError(t, err)
-	assert.Equal(t, frame, output)
-}
-
 func TestEncodeSubscriptionState(t *testing.T) {
 	state := (*subscriptionState)(&collection.LWWSet{
 		Set: collection.LWWState{"A": {AddTime: 10, DelTime: 50}},

--- a/broker/cluster/swarm.go
+++ b/broker/cluster/swarm.go
@@ -20,6 +20,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/config"
 	"github.com/emitter-io/emitter/logging"
@@ -43,7 +44,7 @@ type Swarm struct {
 
 	OnSubscribe   func(subscription.Ssid, subscription.Subscriber) bool // Delegate to invoke when the subscription event is received.
 	OnUnsubscribe func(subscription.Ssid, subscription.Subscriber) bool // Delegate to invoke when the subscription event is received.
-	OnMessage     func(*Message)                                        // Delegate to invoke when a new message is received.
+	OnMessage     func(*message.Message)                                // Delegate to invoke when a new message is received.
 }
 
 // Swarm implements mesh.Gossiper.
@@ -255,7 +256,7 @@ func (s *Swarm) OnGossipBroadcast(src mesh.PeerName, buf []byte) (delta mesh.Gos
 func (s *Swarm) OnGossipUnicast(src mesh.PeerName, buf []byte) (err error) {
 
 	// Decode an incoming message frame
-	frame, err := decodeMessageFrame(buf)
+	frame, err := message.DecodeFrame(buf)
 	if err != nil {
 		logging.LogError("swarm", "decode frame", err)
 		return err

--- a/broker/cluster/swarm.go
+++ b/broker/cluster/swarm.go
@@ -21,7 +21,6 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/message"
-	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/config"
 	"github.com/emitter-io/emitter/logging"
 	"github.com/emitter-io/emitter/network/address"
@@ -42,9 +41,9 @@ type Swarm struct {
 	gossip  mesh.Gossip           // The gossip protocol.
 	members *sync.Map             // The map of members in the peer set.
 
-	OnSubscribe   func(subscription.Ssid, subscription.Subscriber) bool // Delegate to invoke when the subscription event is received.
-	OnUnsubscribe func(subscription.Ssid, subscription.Subscriber) bool // Delegate to invoke when the subscription event is received.
-	OnMessage     func(*message.Message)                                // Delegate to invoke when a new message is received.
+	OnSubscribe   func(message.Ssid, message.Subscriber) bool // Delegate to invoke when the subscription event is received.
+	OnUnsubscribe func(message.Ssid, message.Subscriber) bool // Delegate to invoke when the subscription event is received.
+	OnMessage     func(*message.Message)                      // Delegate to invoke when a new message is received.
 }
 
 // Swarm implements mesh.Gossiper.
@@ -271,7 +270,7 @@ func (s *Swarm) OnGossipUnicast(src mesh.PeerName, buf []byte) (err error) {
 }
 
 // NotifySubscribe notifies the swarm when a subscription occurs.
-func (s *Swarm) NotifySubscribe(conn security.ID, ssid subscription.Ssid) {
+func (s *Swarm) NotifySubscribe(conn security.ID, ssid message.Ssid) {
 	event := SubscriptionEvent{
 		Peer: s.name,
 		Conn: conn,
@@ -288,7 +287,7 @@ func (s *Swarm) NotifySubscribe(conn security.ID, ssid subscription.Ssid) {
 }
 
 // NotifyUnsubscribe notifies the swarm when an unsubscription occurs.
-func (s *Swarm) NotifyUnsubscribe(conn security.ID, ssid subscription.Ssid) {
+func (s *Swarm) NotifyUnsubscribe(conn security.ID, ssid message.Ssid) {
 	event := SubscriptionEvent{
 		Peer: s.name,
 		Conn: conn,

--- a/broker/cluster/swarm_test.go
+++ b/broker/cluster/swarm_test.go
@@ -4,14 +4,13 @@ import (
 	"testing"
 
 	"github.com/emitter-io/emitter/broker/message"
-	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestOnGossipUnicast(t *testing.T) {
 	frame := message.Frame{
-		{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
-		{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
+		{Ssid: message.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
+		{Ssid: message.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
 	}
 
 	// Encode using binary + snappy

--- a/broker/cluster/swarm_test.go
+++ b/broker/cluster/swarm_test.go
@@ -3,14 +3,15 @@ package cluster
 import (
 	"testing"
 
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestOnGossipUnicast(t *testing.T) {
-	frame := MessageFrame{
-		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
-		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
+	frame := message.Frame{
+		{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
+		{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
 	}
 
 	// Encode using binary + snappy
@@ -20,7 +21,7 @@ func TestOnGossipUnicast(t *testing.T) {
 	// Create a dummy swarm
 	var count int
 	swarm := Swarm{
-		OnMessage: func(m *Message) {
+		OnMessage: func(m *message.Message) {
 			assert.Equal(t, frame[count], *m)
 			count++
 		},

--- a/broker/handlers.go
+++ b/broker/handlers.go
@@ -20,9 +20,9 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/subscription"
-	"github.com/emitter-io/emitter/encoding"
 	"github.com/emitter-io/emitter/logging"
 	"github.com/emitter-io/emitter/security"
+	"github.com/emitter-io/emitter/utils"
 )
 
 const (
@@ -310,14 +310,14 @@ func (s *Service) onPresenceQuery(queryType string, payload []byte) ([]byte, boo
 
 	// Decode the request
 	var target subscription.Ssid
-	if err := encoding.Decode(payload, &target); err != nil {
+	if err := utils.Decode(payload, &target); err != nil {
 		return nil, false
 	}
 
 	logging.LogTarget("query", queryType+" query received", target)
 
 	// Send back the response
-	if b, err := encoding.Encode(s.lookupPresence(target)); err == nil {
+	if b, err := utils.Encode(s.lookupPresence(target)); err == nil {
 		return b, true
 	}
 	return nil, false
@@ -397,13 +397,13 @@ func (c *Conn) onPresence(payload []byte) (interface{}, bool) {
 		who = append(who, c.service.lookupPresence(ssid)...)
 
 		// Issue the presence query to the cluster
-		if req, err := encoding.Encode(ssid); err == nil {
+		if req, err := utils.Encode(ssid); err == nil {
 			if awaiter, err := c.service.Query("presence", req); err == nil {
 
 				// Wait for all presence updates to come back (or a deadline)
 				for _, resp := range awaiter.Gather(1000 * time.Millisecond) {
 					info := []presenceInfo{}
-					if err := encoding.Decode(resp, &info); err == nil {
+					if err := utils.Decode(resp, &info); err == nil {
 						//logging.LogTarget("query", "response gathered", info)
 						who = append(who, info...)
 					}

--- a/broker/handlers_dto.go
+++ b/broker/handlers_dto.go
@@ -4,7 +4,7 @@ import (
 	"encoding/json"
 	"time"
 
-	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/logging"
 	"github.com/emitter-io/emitter/security"
 )
@@ -120,17 +120,17 @@ type presenceInfo struct {
 
 // presenceNotify represents a state notification.
 type presenceNotify struct {
-	Time    int64             `json:"time"`    // The UNIX timestamp.
-	Event   presenceEvent     `json:"event"`   // The event, must be "status", "subscribe" or "unsubscribe".
-	Channel string            `json:"channel"` // The target channel for the notification.
-	Who     presenceInfo      `json:"who"`     // The subscriber id.
-	Ssid    subscription.Ssid `json:"-"`       // The ssid to dispatch the notification on.
+	Time    int64         `json:"time"`    // The UNIX timestamp.
+	Event   presenceEvent `json:"event"`   // The event, must be "status", "subscribe" or "unsubscribe".
+	Channel string        `json:"channel"` // The target channel for the notification.
+	Who     presenceInfo  `json:"who"`     // The subscriber id.
+	Ssid    message.Ssid  `json:"-"`       // The ssid to dispatch the notification on.
 }
 
 // newPresenceNotify creates a new notification payload.
-func newPresenceNotify(ssid subscription.Ssid, event presenceEvent, channel string, id string, username string) *presenceNotify {
+func newPresenceNotify(ssid message.Ssid, event presenceEvent, channel string, id string, username string) *presenceNotify {
 	return &presenceNotify{
-		Ssid:    subscription.NewSsidForPresence(ssid),
+		Ssid:    message.NewSsidForPresence(ssid),
 		Time:    time.Now().UTC().Unix(),
 		Event:   event,
 		Channel: channel,

--- a/broker/handlers_test.go
+++ b/broker/handlers_test.go
@@ -3,7 +3,7 @@ package broker
 import (
 	"testing"
 
-	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/broker/message"
 	netmock "github.com/emitter-io/emitter/network/mock"
 	"github.com/emitter-io/emitter/security"
 	secmock "github.com/emitter-io/emitter/security/mock"
@@ -15,7 +15,7 @@ import (
 func TestHandlers_onMe(t *testing.T) {
 	license, _ := security.ParseLicense(testLicense)
 	s := &Service{
-		subscriptions: subscription.NewTrie(),
+		subscriptions: message.NewTrie(),
 		License:       license,
 	}
 
@@ -131,7 +131,7 @@ func TestHandlers_onSubscribeUnsubscribe(t *testing.T) {
 
 		s := &Service{
 			contracts:     provider,
-			subscriptions: subscription.NewTrie(),
+			subscriptions: message.NewTrie(),
 			License:       license,
 			presence:      make(chan *presenceNotify, 100),
 		}
@@ -147,7 +147,7 @@ func TestHandlers_onSubscribeUnsubscribe(t *testing.T) {
 		// Search for the ssid.
 		channel := security.ParseChannel([]byte(tc.channel))
 		key, _ := s.Cipher.DecryptKey(channel.Key)
-		ssid := subscription.NewSsid(key.Contract(), channel)
+		ssid := message.NewSsid(key.Contract(), channel)
 		subscribers := s.subscriptions.Lookup(ssid)
 		assert.Equal(t, tc.subCount, len(subscribers))
 
@@ -257,7 +257,7 @@ func TestHandlers_onPublish(t *testing.T) {
 
 		s := &Service{
 			contracts:     provider,
-			subscriptions: subscription.NewTrie(),
+			subscriptions: message.NewTrie(),
 			License:       license,
 		}
 
@@ -352,7 +352,7 @@ func TestHandlers_onPresence(t *testing.T) {
 
 		s := &Service{
 			contracts:     provider,
-			subscriptions: subscription.NewTrie(),
+			subscriptions: message.NewTrie(),
 			License:       license,
 		}
 

--- a/broker/message/message.go
+++ b/broker/message/message.go
@@ -15,7 +15,6 @@
 package message
 
 import (
-	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/utils"
 	"github.com/golang/snappy"
 )
@@ -26,10 +25,10 @@ type Frame []Message
 
 // Message represents a message which has to be forwarded or stored.
 type Message struct {
-	Time    int64             `json:"ts,omitempty"`   // The timestamp of the message
-	Ssid    subscription.Ssid `json:"ssid,omitempty"` // The Ssid of the message
-	Channel []byte            `json:"chan,omitempty"` // The channel of the message
-	Payload []byte            `json:"data,omitempty"` // The payload of the message
+	Time    int64  `json:"ts,omitempty"`   // The timestamp of the message
+	Ssid    Ssid   `json:"ssid,omitempty"` // The Ssid of the message
+	Channel []byte `json:"chan,omitempty"` // The channel of the message
+	Payload []byte `json:"data,omitempty"` // The payload of the message
 }
 
 // Size returns the byte size of the message.
@@ -49,7 +48,7 @@ func (f *Frame) Encode() (out []byte, err error) {
 }
 
 // Append appends the message to a frame.
-func (f *Frame) Append(time int64, ssid subscription.Ssid, channel, payload []byte) {
+func (f *Frame) Append(time int64, ssid Ssid, channel, payload []byte) {
 	*f = append(*f, Message{Time: time, Ssid: ssid, Channel: channel, Payload: payload})
 }
 

--- a/broker/message/message.go
+++ b/broker/message/message.go
@@ -1,0 +1,65 @@
+/**********************************************************************************
+* Copyright (c) 2009-2017 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package message
+
+import (
+	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/utils"
+	"github.com/golang/snappy"
+)
+
+// Frame represents a message frame which is sent through the wire to the
+// remote server and contains a set of messages.
+type Frame []Message
+
+// Message represents a message which has to be forwarded or stored.
+type Message struct {
+	Time    int64             `json:"ts,omitempty"`   // The timestamp of the message
+	Ssid    subscription.Ssid `json:"ssid,omitempty"` // The Ssid of the message
+	Channel []byte            `json:"chan,omitempty"` // The channel of the message
+	Payload []byte            `json:"data,omitempty"` // The payload of the message
+}
+
+// Size returns the byte size of the message.
+func (m *Message) Size() int64 {
+	return int64(len(m.Payload))
+}
+
+// Encode encodes the message frame
+func (f *Frame) Encode() (out []byte, err error) {
+	// TODO: optimize
+	var enc []byte
+	if enc, err = utils.Encode(f); err == nil {
+		out = snappy.Encode(out, enc)
+		return
+	}
+	return
+}
+
+// Append appends the message to a frame.
+func (f *Frame) Append(time int64, ssid subscription.Ssid, channel, payload []byte) {
+	*f = append(*f, Message{Time: time, Ssid: ssid, Channel: channel, Payload: payload})
+}
+
+// DecodeFrame decodes the message frame from the decoder.
+func DecodeFrame(buf []byte) (out Frame, err error) {
+	// TODO: optimize
+	var buffer []byte
+	if buf, err = snappy.Decode(buffer, buf); err == nil {
+		out = make(Frame, 0, 64)
+		err = utils.Decode(buf, &out)
+	}
+	return
+}

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -23,13 +23,6 @@ func TestDecodeFrame(t *testing.T) {
 	assert.Equal(t, frame, output)
 }
 
-func TestFrameAppend(t *testing.T) {
-	var frame Frame
-	frame.Append(1111, Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
-	frame.Append(1111, Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
-	assert.Len(t, frame, 2)
-}
-
 func TestMessageSize(t *testing.T) {
 	m := Message{Payload: []byte("hello abc")}
 	assert.Equal(t, int64(9), m.Size())

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -1,0 +1,67 @@
+package message
+
+import (
+	"testing"
+
+	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/utils"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestDecodeFrame(t *testing.T) {
+	frame := Frame{
+		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
+		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
+	}
+
+	// Encode
+	buffer, err := frame.Encode()
+	assert.NoError(t, err)
+
+	// Decode
+	output, err := DecodeFrame(buffer)
+	assert.NoError(t, err)
+	assert.Equal(t, frame, output)
+}
+
+func TestFrameAppend(t *testing.T) {
+	var frame Frame
+	frame.Append(1111, subscription.Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
+	frame.Append(1111, subscription.Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
+	assert.Len(t, frame, 2)
+}
+
+func TestMessageSize(t *testing.T) {
+	m := Message{Payload: []byte("hello abc")}
+	assert.Equal(t, int64(9), m.Size())
+}
+
+func BenchmarkEncode(b *testing.B) {
+	m := Frame{{
+		Time:    1234,
+		Channel: []byte("tweet/canada/english/"),
+		Payload: []byte("This is a random tweet en english so we can test the payload. #emitter"),
+		Ssid:    []uint32{1, 2, 3},
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		utils.Encode(&m)
+	}
+}
+
+func BenchmarkEncodeWithSnappy(b *testing.B) {
+	m := Frame{{
+		Time:    1234,
+		Channel: []byte("tweet/canada/english/"),
+		Payload: []byte("This is a random tweet en english so we can test the payload. #emitter"),
+		Ssid:    []uint32{1, 2, 3},
+	}}
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		m.Encode()
+	}
+}

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -3,15 +3,14 @@ package message
 import (
 	"testing"
 
-	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/utils"
 	"github.com/stretchr/testify/assert"
 )
 
 func TestDecodeFrame(t *testing.T) {
 	frame := Frame{
-		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
-		Message{Ssid: subscription.Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
+		Message{Ssid: Ssid{1, 2, 3}, Channel: []byte("a/b/c/"), Payload: []byte("hello abc")},
+		Message{Ssid: Ssid{1, 2, 3}, Channel: []byte("a/b/"), Payload: []byte("hello ab")},
 	}
 
 	// Encode
@@ -26,8 +25,8 @@ func TestDecodeFrame(t *testing.T) {
 
 func TestFrameAppend(t *testing.T) {
 	var frame Frame
-	frame.Append(1111, subscription.Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
-	frame.Append(1111, subscription.Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
+	frame.Append(1111, Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
+	frame.Append(1111, Ssid{1, 2, 3}, []byte("a/b/c/"), []byte("hello abc"))
 	assert.Len(t, frame, 2)
 }
 

--- a/broker/message/sub.go
+++ b/broker/message/sub.go
@@ -12,7 +12,7 @@
 * with this program. If not, see<http://www.gnu.org/licenses/>.
 ************************************************************************************/
 
-package subscription
+package message
 
 import (
 	"encoding/binary"
@@ -120,7 +120,7 @@ const (
 type Subscriber interface {
 	ID() string
 	Type() SubscriberType
-	Send(ssid Ssid, channel []byte, payload []byte) error
+	Send(*Message) error
 }
 
 // ------------------------------------------------------------------------------------

--- a/broker/message/sub_test.go
+++ b/broker/message/sub_test.go
@@ -1,4 +1,4 @@
-package subscription
+package message
 
 import (
 	"testing"

--- a/broker/message/subtrie.go
+++ b/broker/message/subtrie.go
@@ -12,7 +12,7 @@
 * with this program. If not, see<http://www.gnu.org/licenses/>.
 ************************************************************************************/
 
-package subscription
+package message
 
 import (
 	"sync/atomic"

--- a/broker/message/subtrie_test.go
+++ b/broker/message/subtrie_test.go
@@ -1,4 +1,4 @@
-package subscription
+package message
 
 import (
 	"math/rand"
@@ -21,7 +21,7 @@ func (s *testSubscriber) Type() SubscriberType {
 	return SubscriberDirect
 }
 
-func (s *testSubscriber) Send(ssid Ssid, channel []byte, payload []byte) error {
+func (s *testSubscriber) Send(*Message) error {
 	return nil
 }
 

--- a/broker/query.go
+++ b/broker/query.go
@@ -150,7 +150,12 @@ func (c *QueryManager) Query(query string, payload []byte) (message.Awaiter, err
 	channel := fmt.Sprintf("%v/%v", query, c.service.LocalName())
 
 	// Publish the query as a message
-	c.service.publish(message.Ssid{idSystem, idQuery, awaiter.id}, []byte(channel), payload)
+	c.service.publish(&message.Message{
+		Ssid:    message.Ssid{idSystem, idQuery, awaiter.id},
+		Channel: []byte(channel),
+		Payload: payload,
+	})
+
 	return awaiter, nil
 }
 

--- a/broker/query.go
+++ b/broker/query.go
@@ -23,7 +23,7 @@ import (
 	"sync/atomic"
 	"time"
 
-	"github.com/emitter-io/emitter/broker/subscription"
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/security"
 	"github.com/weaveworks/mesh"
 )
@@ -58,7 +58,7 @@ func newQueryManager(s *Service) *QueryManager {
 
 // Start subscribes the manager to the query channel.
 func (c *QueryManager) Start() {
-	ssid := subscription.Ssid{idSystem, idQuery}
+	ssid := message.Ssid{idSystem, idQuery}
 	if ok := c.service.onSubscribe(ssid, c); ok {
 		c.service.cluster.NotifySubscribe(c.luid, ssid)
 	}
@@ -75,24 +75,24 @@ func (c *QueryManager) ID() string {
 }
 
 // Type returns the type of the subscriber
-func (c *QueryManager) Type() subscription.SubscriberType {
-	return subscription.SubscriberDirect
+func (c *QueryManager) Type() message.SubscriberType {
+	return message.SubscriberDirect
 }
 
 // Send occurs when we have received a message.
-func (c *QueryManager) Send(ssid subscription.Ssid, channel []byte, payload []byte) error {
-	if len(ssid) != 3 {
+func (c *QueryManager) Send(m *message.Message) error {
+	if len(m.Ssid) != 3 {
 		return errors.New("Invalid query received")
 	}
 
-	switch string(channel) {
+	switch string(m.Channel) {
 	case "response":
 		// We received a response, find the awaiter and forward a message to it
-		return c.onResponse(ssid[2], payload)
+		return c.onResponse(m.Ssid[2], m.Payload)
 
 	default:
 		// We received a request, need to handle that by calling the appropriate handler
-		return c.onRequest(ssid, string(channel), payload)
+		return c.onRequest(m.Ssid, string(m.Channel), m.Payload)
 	}
 }
 
@@ -105,7 +105,7 @@ func (c *QueryManager) onResponse(id uint32, payload []byte) error {
 }
 
 // onRequest handles an incoming request
-func (c *QueryManager) onRequest(ssid subscription.Ssid, channel string, payload []byte) error {
+func (c *QueryManager) onRequest(ssid message.Ssid, channel string, payload []byte) error {
 	// Get the query and reply node
 	ch := strings.Split(channel, "/")
 	query := ch[0]
@@ -120,7 +120,11 @@ func (c *QueryManager) onRequest(ssid subscription.Ssid, channel string, payload
 	// Go through all the handlers and execute the first matching one
 	for _, handle := range c.handlers {
 		if response, ok := handle(query, payload); ok {
-			return peer.Send(ssid, []byte("response"), response)
+			return peer.Send(&message.Message{
+				Ssid:    ssid,
+				Channel: []byte("response"),
+				Payload: response,
+			})
 		}
 	}
 
@@ -128,7 +132,7 @@ func (c *QueryManager) onRequest(ssid subscription.Ssid, channel string, payload
 }
 
 // Query issues a cluster-wide request.
-func (c *QueryManager) Query(query string, payload []byte) (subscription.Awaiter, error) {
+func (c *QueryManager) Query(query string, payload []byte) (message.Awaiter, error) {
 
 	// Create an awaiter
 	// TODO: replace the max with the total number of cluster nodes
@@ -146,7 +150,7 @@ func (c *QueryManager) Query(query string, payload []byte) (subscription.Awaiter
 	channel := fmt.Sprintf("%v/%v", query, c.service.LocalName())
 
 	// Publish the query as a message
-	c.service.publish(subscription.Ssid{idSystem, idQuery, awaiter.id}, []byte(channel), payload)
+	c.service.publish(message.Ssid{idSystem, idQuery, awaiter.id}, []byte(channel), payload)
 	return awaiter, nil
 }
 

--- a/broker/service.go
+++ b/broker/service.go
@@ -28,6 +28,7 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/cluster"
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/broker/storage"
 	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/config"
@@ -305,7 +306,7 @@ func (s *Service) onUnsubscribe(ssid subscription.Ssid, sub subscription.Subscri
 }
 
 // Occurs when a message is received from a peer.
-func (s *Service) onPeerMessage(m *cluster.Message) {
+func (s *Service) onPeerMessage(m *message.Message) {
 	// Get the contract
 	contract, contractFound := s.contracts.Get(m.Ssid.Contract())
 

--- a/broker/storage/memory.go
+++ b/broker/storage/memory.go
@@ -24,7 +24,6 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/message"
-	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/utils"
 	"github.com/karlseguin/ccache"
 )
@@ -44,9 +43,9 @@ var _ Storage = new(InMemory)
 
 // InMemory represents a storage which does nothing.
 type InMemory struct {
-	cur   *sync.Map                                          // The cursor map which stores the last written offset.
-	mem   *ccache.Cache                                      // The LRU cache with TTL.
-	Query func(string, []byte) (subscription.Awaiter, error) // The cluster request function.
+	cur   *sync.Map                                     // The cursor map which stores the last written offset.
+	mem   *ccache.Cache                                 // The LRU cache with TTL.
+	Query func(string, []byte) (message.Awaiter, error) // The cluster request function.
 }
 
 // Name returns the name of the provider.
@@ -73,7 +72,7 @@ func (s *InMemory) Configure(config map[string]interface{}) error {
 func (s *InMemory) Store(ssid []uint32, payload []byte, ttl time.Duration) error {
 
 	// Get the string version of the SSID trunk
-	key := subscription.Ssid(ssid).Encode()
+	key := message.Ssid(ssid).Encode()
 	trunk := key[:16]
 
 	// Get and increment the last message cursor
@@ -161,7 +160,7 @@ func (s *InMemory) lookup(q lookupQuery) (matches message.Frame) {
 	matchCount := 0
 
 	// Get the string version of the SSID trunk
-	key := subscription.Ssid(q.Ssid).Encode()
+	key := message.Ssid(q.Ssid).Encode()
 	trunk := key[:16]
 
 	// Get the value of the last message cursor

--- a/broker/storage/memory.go
+++ b/broker/storage/memory.go
@@ -24,7 +24,7 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/subscription"
-	"github.com/emitter-io/emitter/encoding"
+	"github.com/emitter-io/emitter/utils"
 	"github.com/karlseguin/ccache"
 )
 
@@ -108,13 +108,13 @@ func (s *InMemory) QueryLast(ssid []uint32, limit int) (<-chan []byte, error) {
 	match := s.lookup(query)
 
 	// Issue the presence query to the cluster
-	if req, err := encoding.Encode(query); err == nil && s.Query != nil {
+	if req, err := utils.Encode(query); err == nil && s.Query != nil {
 		if awaiter, err := s.Query("memstore", req); err == nil {
 
 			// Wait for all presence updates to come back (or a deadline)
 			for _, resp := range awaiter.Gather(2000 * time.Millisecond) {
 				info := []message{}
-				if err := encoding.Decode(resp, &info); err == nil {
+				if err := utils.Decode(resp, &info); err == nil {
 					match = append(match, info...)
 				}
 			}
@@ -150,7 +150,7 @@ func (s *InMemory) OnRequest(queryType string, payload []byte) ([]byte, bool) {
 
 	// Decode the request
 	var query lookupQuery
-	if err := encoding.Decode(payload, &query); err != nil {
+	if err := utils.Decode(payload, &query); err != nil {
 		return nil, false
 	}
 
@@ -162,7 +162,7 @@ func (s *InMemory) OnRequest(queryType string, payload []byte) ([]byte, bool) {
 	//logging.LogTarget("memstore", queryType+" query received", query)
 
 	// Send back the response
-	b, err := encoding.Encode(s.lookup(query))
+	b, err := utils.Encode(s.lookup(query))
 	return b, err == nil
 }
 

--- a/broker/storage/memory_test.go
+++ b/broker/storage/memory_test.go
@@ -27,12 +27,13 @@ type testStorageConfig struct {
 func newTestMemStore() *InMemory {
 	s := new(InMemory)
 	s.Configure(nil)
-	s.Store([]uint32{0, 1, 1, 1}, []byte("1,1,1"), 10*time.Second)
-	s.Store([]uint32{0, 1, 1, 2}, []byte("1,1,2"), 10*time.Second)
-	s.Store([]uint32{0, 1, 2, 1}, []byte("1,2,1"), 10*time.Second)
-	s.Store([]uint32{0, 1, 2, 2}, []byte("1,2,2"), 10*time.Second)
-	s.Store([]uint32{0, 1, 3, 1}, []byte("1,3,1"), 10*time.Second)
-	s.Store([]uint32{0, 1, 3, 2}, []byte("1,3,2"), 10*time.Second)
+
+	s.Store(testMessage(1, 1, 1), 10*time.Second)
+	s.Store(testMessage(1, 1, 2), 10*time.Second)
+	s.Store(testMessage(1, 2, 1), 10*time.Second)
+	s.Store(testMessage(1, 2, 2), 10*time.Second)
+	s.Store(testMessage(1, 3, 1), 10*time.Second)
+	s.Store(testMessage(1, 3, 2), 10*time.Second)
 	return s
 }
 
@@ -59,9 +60,9 @@ func TestInMemory_Store(t *testing.T) {
 	s := new(InMemory)
 	s.Configure(nil)
 
-	err := s.Store([]uint32{1, 2, 3}, []byte("test"), 10*time.Second)
+	err := s.Store(testMessage(1, 2, 3), 10*time.Second)
 	assert.NoError(t, err)
-	assert.Equal(t, []byte("test"), s.mem.Get("0000000100000002:1").Value().(message.Message).Payload)
+	assert.Equal(t, []byte("1,2,3"), s.mem.Get("0000000000000001:1").Value().(message.Message).Payload)
 }
 
 func TestInMemory_QueryLast(t *testing.T) {

--- a/broker/storage/memory_test.go
+++ b/broker/storage/memory_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/utils"
 	"github.com/stretchr/testify/assert"
@@ -61,8 +62,7 @@ func TestInMemory_Store(t *testing.T) {
 
 	err := s.Store([]uint32{1, 2, 3}, []byte("test"), 10*time.Second)
 	assert.NoError(t, err)
-
-	assert.Equal(t, []byte("test"), s.mem.Get("0000000100000002:1").Value().(message).Payload)
+	assert.Equal(t, []byte("test"), s.mem.Get("0000000100000002:1").Value().(message.Message).Payload)
 }
 
 func TestInMemory_QueryLast(t *testing.T) {
@@ -157,9 +157,7 @@ func TestInMemory_OnRequest(t *testing.T) {
 		resp, ok := s.OnRequest(tc.name, q)
 		assert.Equal(t, tc.expectOk, ok)
 		if tc.expectOk && ok {
-
-			var msgs []message
-			err := utils.Decode(resp, &msgs)
+			msgs, err := message.DecodeFrame(resp)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectCount, len(msgs))
 		}
@@ -183,9 +181,4 @@ func Test_param(t *testing.T) {
 
 	v := param(cfg.Config, "maxsize", 0)
 	assert.Equal(t, int64(99999999), v)
-}
-
-func Test_messageSize(t *testing.T) {
-	msg := message{Ssid: "abc", Payload: []byte("hello")}
-	assert.Equal(t, int64(5), msg.Size())
 }

--- a/broker/storage/memory_test.go
+++ b/broker/storage/memory_test.go
@@ -6,7 +6,6 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/message"
-	"github.com/emitter-io/emitter/broker/subscription"
 	"github.com/emitter-io/emitter/utils"
 	"github.com/stretchr/testify/assert"
 )
@@ -89,7 +88,7 @@ func TestInMemory_QueryLast(t *testing.T) {
 		if tc.gathered == nil {
 			s.Query = nil
 		} else {
-			s.Query = func(string, []byte) (subscription.Awaiter, error) {
+			s.Query = func(string, []byte) (message.Awaiter, error) {
 				return &mockAwaiter{f: func(_ time.Duration) [][]byte { return [][]byte{tc.gathered} }}, nil
 			}
 		}

--- a/broker/storage/memory_test.go
+++ b/broker/storage/memory_test.go
@@ -6,7 +6,7 @@ import (
 	"time"
 
 	"github.com/emitter-io/emitter/broker/subscription"
-	"github.com/emitter-io/emitter/encoding"
+	"github.com/emitter-io/emitter/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -153,13 +153,13 @@ func TestInMemory_OnRequest(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		q, _ := encoding.Encode(tc.query)
+		q, _ := utils.Encode(tc.query)
 		resp, ok := s.OnRequest(tc.name, q)
 		assert.Equal(t, tc.expectOk, ok)
 		if tc.expectOk && ok {
 
 			var msgs []message
-			err := encoding.Decode(resp, &msgs)
+			err := utils.Decode(resp, &msgs)
 			assert.NoError(t, err)
 			assert.Equal(t, tc.expectCount, len(msgs))
 		}

--- a/broker/storage/storage.go
+++ b/broker/storage/storage.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/emitter-io/config"
+	"github.com/emitter-io/emitter/broker/message"
 )
 
 // Storage represents a message storage contract that message storage provides
@@ -31,7 +32,7 @@ type Storage interface {
 	// SSID, where first element should be a contract ID. The time resolution
 	// for TTL will be in seconds. The function is executed synchronously and
 	// it returns an error if some error was encountered during storage.
-	Store(ssid []uint32, payload []byte, ttl time.Duration) error
+	Store(m *message.Message, ttl time.Duration) error
 
 	// QueryLast performs a query and attempts to fetch last n messages where
 	// n is specified by limit argument. It returns a channel which will be
@@ -63,7 +64,7 @@ func (s *Noop) Configure(config map[string]interface{}) error {
 // SSID, where first element should be a contract ID. The time resolution
 // for TTL will be in seconds. The function is executed synchronously and
 // it returns an error if some error was encountered during storage.
-func (s *Noop) Store(ssid []uint32, payload []byte, ttl time.Duration) error {
+func (s *Noop) Store(m *message.Message, ttl time.Duration) error {
 	return nil
 }
 

--- a/broker/storage/storage_test.go
+++ b/broker/storage/storage_test.go
@@ -1,21 +1,32 @@
 package storage
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
+	"github.com/emitter-io/emitter/broker/message"
 	"github.com/stretchr/testify/assert"
 )
 
+func testMessage(a, b, c uint32) *message.Message {
+	return &message.Message{
+		Time:    1354678,
+		Ssid:    []uint32{0, a, b, c},
+		Channel: []byte("test/channel/"),
+		Payload: []byte(fmt.Sprintf("%v,%v,%v", a, b, c)),
+	}
+}
+
 func TestNoop_Store(t *testing.T) {
 	s := new(Noop)
-	err := s.Store([]uint32{1, 2, 3}, []byte("test"), 10*time.Second)
+	err := s.Store(testMessage(1, 2, 3), 10*time.Second)
 	assert.NoError(t, err)
 }
 
 func TestNoop_QueryLast(t *testing.T) {
 	s := new(Noop)
-	r, err := s.QueryLast([]uint32{1, 2, 3}, 10)
+	r, err := s.QueryLast(testMessage(1, 2, 3).Ssid, 10)
 	assert.NoError(t, err)
 	for range r {
 		t.Errorf("Should be empty")

--- a/utils/codec.go
+++ b/utils/codec.go
@@ -1,4 +1,4 @@
-package encoding
+package utils
 
 import (
 	"github.com/kelindar/binary"

--- a/utils/codec_test.go
+++ b/utils/codec_test.go
@@ -1,4 +1,4 @@
-package encoding
+package utils
 
 import (
 	"testing"


### PR DESCRIPTION
This creates a streamlined and unified `message` package containing a `Message` struct and a `Frame` struct. This package is now used by storage and message forwarding implementations . I also did some refactoring work to make the code cleaner and easier to read.