### PR TITLE
fixed cluster query which would answer its own requests

### DIFF
--- a/broker/cluster/swarm.go
+++ b/broker/cluster/swarm.go
@@ -244,6 +244,11 @@ func (s *Swarm) OnGossip(buf []byte) (delta mesh.GossipData, err error) {
 // OnGossipBroadcast merges received data into state and returns a representation
 // of the received data (typically a delta) for further propagation.
 func (s *Swarm) OnGossipBroadcast(src mesh.PeerName, buf []byte) (delta mesh.GossipData, err error) {
+	if src == s.name {
+		logging.LogAction("merge", "got our own broadcast")
+		return
+	}
+
 	if delta, err = s.merge(buf); err != nil {
 		logging.LogError("merge", "merging", err)
 	}

--- a/broker/conn.go
+++ b/broker/conn.go
@@ -212,7 +212,7 @@ func (c *Conn) Unsubscribe(ssid message.Ssid, channel []byte) {
 
 // Close terminates the connection.
 func (c *Conn) Close() error {
-	logging.LogTarget("conn", "closed", c.luid)
+	logging.LogTarget("conn", "closed", c.guid)
 
 	// Unsubscribe from everything, no need to lock since each Unsubscribe is
 	// already locked. Locking the 'Close()' would result in a deadlock.

--- a/broker/query.go
+++ b/broker/query.go
@@ -114,8 +114,14 @@ func (c *QueryManager) onRequest(ssid message.Ssid, channel string, payload []by
 		return err
 	}
 
+	// Do not answer our own requests
+	replyAddr := mesh.PeerName(reply)
+	if c.service.cluster.ID() == uint64(replyAddr) {
+		return nil
+	}
+
 	// Get the peer to reply to
-	peer := c.service.cluster.FindPeer(mesh.PeerName(reply))
+	peer := c.service.cluster.FindPeer(replyAddr)
 
 	// Go through all the handlers and execute the first matching one
 	for _, handle := range c.handlers {

--- a/broker/service.go
+++ b/broker/service.go
@@ -57,6 +57,7 @@ type Service struct {
 	contracts     security.ContractProvider // The contract provider for the service.
 	storage       storage.Storage           // The storage provider for the service.
 	metering      usage.Metering            // The usage storage for metering contracts.
+	connections   int64                     // The number of currently open connections.
 }
 
 // NewService creates a new service.

--- a/broker/status.go
+++ b/broker/status.go
@@ -14,6 +14,7 @@ type StatusInfo struct {
 	Node          string    `json:"node"`
 	Addr          string    `json:"addr"`
 	Subscriptions int       `json:"subs"`
+	Connections   int64     `json:"conns"`
 	CPU           float64   `json:"cpu"`
 	MemoryPrivate int64     `json:"priv"`
 	MemoryVirtual int64     `json:"virt"`
@@ -31,6 +32,7 @@ func (s *Service) getStatus() (*StatusInfo, error) {
 	stats.Node = address.Fingerprint(s.LocalName()).String()
 	stats.Addr = address.External().String()
 	stats.Subscriptions = 0 // TODO: Set subscriptions
+	stats.Connections = s.connections
 	stats.Time = t
 	stats.Uptime = t.Sub(s.startTime).Seconds()
 	stats.NumPeers = s.NumPeers()


### PR DESCRIPTION
This one is kinda tricky, the `QueryManager` implements a Subscriber interface and subscribes to `0/query/` so it can receive queries sent from other nodes of the cluster. However, it did not ignore its own requests so it would attempt to find and connect to its own "peer" and issue gossip query through, which would then fail.