### PR TITLE
resolving the seed hostname on join

### DIFF
--- a/broker/cluster/swarm.go
+++ b/broker/cluster/swarm.go
@@ -172,8 +172,23 @@ func (s *Swarm) update() {
 }
 
 // Join attempts to join a set of existing peers.
-func (s *Swarm) Join(peers ...string) []error {
-	return s.router.ConnectionMaker.InitiateConnections(peers, false)
+func (s *Swarm) Join(peers ...string) (errs []error) {
+
+	// Resolve the host-names of the peers provided
+	var addrs []string
+	for _, h := range peers {
+		ips, err := net.LookupHost(h)
+		if err != nil {
+			errs = append(errs, err)
+		}
+		addrs = append(addrs, ips...)
+	}
+
+	// Use all the available addresses to initiate the connections
+	if s.router != nil {
+		errs = s.router.ConnectionMaker.InitiateConnections(addrs, false)
+	}
+	return
 }
 
 // Merge merges the incoming state and returns a delta

--- a/broker/cluster/swarm_test.go
+++ b/broker/cluster/swarm_test.go
@@ -130,3 +130,10 @@ func Test_merge(t *testing.T) {
 	assert.NoError(t, err)
 	assert.True(t, subscribed)
 }
+
+func TestJoin(t *testing.T) {
+	s := new(Swarm)
+
+	errs := s.Join("google.com", "127.0.0.1")
+	assert.Empty(t, errs)
+}


### PR DESCRIPTION
With this, the broker will resolve a seed domain name and attempt to join all the nodes registered (see  https://github.com/emitter-io/emitter/issues/18). This should make simultaneous cluster restarts more robust.