### PR TITLE
adding HTTP message storage provider

### DIFF
--- a/broker/cluster/swarm_test.go
+++ b/broker/cluster/swarm_test.go
@@ -1,13 +1,13 @@
 package cluster
 
 import (
-	"github.com/weaveworks/mesh"
 	"io"
 	"testing"
 
 	"github.com/emitter-io/emitter/broker/message"
 	"github.com/emitter-io/emitter/config"
 	"github.com/stretchr/testify/assert"
+	"github.com/weaveworks/mesh"
 )
 
 func TestOnGossipUnicast(t *testing.T) {

--- a/broker/cluster/swarm_test.go
+++ b/broker/cluster/swarm_test.go
@@ -134,6 +134,6 @@ func Test_merge(t *testing.T) {
 func TestJoin(t *testing.T) {
 	s := new(Swarm)
 
-	errs := s.Join("google.com", "127.0.0.1")
+	errs := s.Join("google.com", "127.0.0.1", "127.0.0.1:4000")
 	assert.Empty(t, errs)
 }

--- a/broker/service.go
+++ b/broker/service.go
@@ -114,11 +114,9 @@ func NewService(cfg *config.Config) (s *Service, err error) {
 	logging.LogTarget("service", "configured logging provider", logging.Logger.Name())
 
 	// Load the storage provider
-	memstore := &storage.InMemory{Query: s.Query}
+	memstore := storage.NewInMemory(s.Query)
 	s.querier.HandleFunc(memstore.OnRequest)
-	s.storage = config.LoadProvider(cfg.Storage,
-		new(storage.Noop),
-		memstore).(storage.Storage)
+	s.storage = config.LoadProvider(cfg.Storage, storage.NewNoop(), storage.NewHTTP(), memstore).(storage.Storage)
 	logging.LogTarget("service", "configured storage provider", s.storage.Name())
 
 	// Load the metering provider

--- a/broker/storage/http.go
+++ b/broker/storage/http.go
@@ -42,7 +42,8 @@ type HTTP struct {
 // NewHTTP creates a new HTTP storage.
 func NewHTTP() *HTTP {
 	return &HTTP{
-		done: make(chan bool),
+		frame: make(message.Frame, 0, 64),
+		done:  make(chan bool),
 	}
 }
 
@@ -95,7 +96,7 @@ func (s *HTTP) Store(m *message.Message) error {
 // n is specified by limit argument. It returns a channel which will be
 // ranged over to retrieve messages asynchronously.
 func (s *HTTP) QueryLast(ssid []uint32, limit int) (ch <-chan []byte, err error) {
-	re := make(chan []byte)
+	re := make(chan []byte, limit)
 	ch = re // We need to return the same channel, but receive only
 
 	// Get the raw bytes
@@ -115,6 +116,7 @@ func (s *HTTP) QueryLast(ssid []uint32, limit int) (ch <-chan []byte, err error)
 	if err != nil {
 		close(re)
 	}
+
 	return
 }
 

--- a/broker/storage/http.go
+++ b/broker/storage/http.go
@@ -127,9 +127,13 @@ func (s *HTTP) Close() error {
 
 // Store periodically flushes the pending queue.
 func (s *HTTP) store() {
+	s.Lock()
+	if len(s.frame) == 0 {
+		s.Unlock()
+		return
+	}
 
 	// Encode the frame
-	s.Lock()
 	buffer, _ := s.frame.Encode()
 	s.frame = s.frame[:0]
 	s.Unlock()

--- a/broker/storage/http.go
+++ b/broker/storage/http.go
@@ -15,52 +15,29 @@
 package storage
 
 import (
-	"io"
-
-	"github.com/emitter-io/config"
 	"github.com/emitter-io/emitter/broker/message"
 )
 
-// Storage represents a message storage contract that message storage provides
-// must fulfill.
-type Storage interface {
-	config.Provider
-	io.Closer
-
-	// Store is used to store a message, the SSID provided must be a full SSID
-	// SSID, where first element should be a contract ID. The time resolution
-	// for TTL will be in seconds. The function is executed synchronously and
-	// it returns an error if some error was encountered during storage.
-	Store(m *message.Message) error
-
-	// QueryLast performs a query and attempts to fetch last n messages where
-	// n is specified by limit argument. It returns a channel which will be
-	// ranged over to retrieve messages asynchronously.
-	QueryLast(ssid []uint32, limit int) (<-chan []byte, error)
-}
-
-// ------------------------------------------------------------------------------------
-
 // Noop implements Storage contract.
-var _ Storage = new(Noop)
+var _ Storage = new(HTTP)
 
-// Noop represents a storage which does nothing.
-type Noop struct{}
+// HTTP represents a storage which uses HTTP requests to store/retrieve messages.
+type HTTP struct{}
 
-// NewNoop creates a new no-op storage.
-func NewNoop() *Noop {
-	return new(Noop)
+// NewHTTP creates a new HTTP storage.
+func NewHTTP() *HTTP {
+	return new(HTTP)
 }
 
 // Name returns the name of the provider.
-func (s *Noop) Name() string {
-	return "noop"
+func (s *HTTP) Name() string {
+	return "http"
 }
 
 // Configure configures the storage. The config parameter provided is
 // loosely typed, since various storage mechanisms will require different
 // configurations.
-func (s *Noop) Configure(config map[string]interface{}) error {
+func (s *HTTP) Configure(config map[string]interface{}) error {
 	return nil
 }
 
@@ -68,14 +45,14 @@ func (s *Noop) Configure(config map[string]interface{}) error {
 // SSID, where first element should be a contract ID. The time resolution
 // for TTL will be in seconds. The function is executed synchronously and
 // it returns an error if some error was encountered during storage.
-func (s *Noop) Store(m *message.Message) error {
+func (s *HTTP) Store(m *message.Message) error {
 	return nil
 }
 
 // QueryLast performs a query and attempts to fetch last n messages where
 // n is specified by limit argument. It returns a channel which will be
 // ranged over to retrieve messages asynchronously.
-func (s *Noop) QueryLast(ssid []uint32, limit int) (<-chan []byte, error) {
+func (s *HTTP) QueryLast(ssid []uint32, limit int) (<-chan []byte, error) {
 	ch := make(chan []byte)
 	close(ch) // Close the channel so we can return a closed one.
 	return ch, nil
@@ -83,6 +60,6 @@ func (s *Noop) QueryLast(ssid []uint32, limit int) (<-chan []byte, error) {
 
 // Close gracefully terminates the storage and ensures that every related
 // resource is properly disposed.
-func (s *Noop) Close() error {
+func (s *HTTP) Close() error {
 	return nil
 }

--- a/broker/storage/http.go
+++ b/broker/storage/http.go
@@ -15,18 +15,35 @@
 package storage
 
 import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"sync"
+	"time"
+
 	"github.com/emitter-io/emitter/broker/message"
+	"github.com/emitter-io/emitter/logging"
+	"github.com/emitter-io/emitter/network/http"
+	"github.com/emitter-io/emitter/utils"
 )
 
 // Noop implements Storage contract.
 var _ Storage = new(HTTP)
 
 // HTTP represents a storage which uses HTTP requests to store/retrieve messages.
-type HTTP struct{}
+type HTTP struct {
+	sync.Mutex
+	frame message.Frame // The pending message frame.
+	base  string        // The base url to use for the storage.
+	http  http.Client   // The http client to use.
+	done  chan bool     // The closing channel.
+}
 
 // NewHTTP creates a new HTTP storage.
 func NewHTTP() *HTTP {
-	return new(HTTP)
+	return &HTTP{
+		done: make(chan bool),
+	}
 }
 
 // Name returns the name of the provider.
@@ -37,8 +54,29 @@ func (s *HTTP) Name() string {
 // Configure configures the storage. The config parameter provided is
 // loosely typed, since various storage mechanisms will require different
 // configurations.
-func (s *HTTP) Configure(config map[string]interface{}) error {
-	return nil
+func (s *HTTP) Configure(config map[string]interface{}) (err error) {
+	if config == nil {
+		return errors.New("Configuration was not provided for HTTP storage")
+	}
+
+	// Get the interval from the provider configuration
+	interval := 10 * time.Millisecond
+	if v, ok := config["interval"]; ok {
+		if i, ok := v.(float64); ok {
+			interval = time.Duration(i) * time.Millisecond
+		}
+	}
+
+	// Get the url from the provider configuration
+	if url, ok := config["url"]; ok {
+		s.base = url.(string)
+		s.http, err = http.NewClient(s.base, 30*time.Second)
+
+		utils.Repeat(s.store, interval, s.done) // TODO: closing chan
+		return
+	}
+
+	return errors.New("The 'url' parameter was not provider in the configuration for HTTP storage")
 }
 
 // Store is used to store a message, the SSID provided must be a full SSID
@@ -46,20 +84,69 @@ func (s *HTTP) Configure(config map[string]interface{}) error {
 // for TTL will be in seconds. The function is executed synchronously and
 // it returns an error if some error was encountered during storage.
 func (s *HTTP) Store(m *message.Message) error {
+	s.Lock()
+	defer s.Unlock()
+
+	s.frame = append(s.frame, *m)
 	return nil
 }
 
 // QueryLast performs a query and attempts to fetch last n messages where
 // n is specified by limit argument. It returns a channel which will be
 // ranged over to retrieve messages asynchronously.
-func (s *HTTP) QueryLast(ssid []uint32, limit int) (<-chan []byte, error) {
-	ch := make(chan []byte)
-	close(ch) // Close the channel so we can return a closed one.
-	return ch, nil
+func (s *HTTP) QueryLast(ssid []uint32, limit int) (ch <-chan []byte, err error) {
+	re := make(chan []byte)
+	ch = re // We need to return the same channel, but receive only
+
+	// Get the raw bytes
+	var resp []byte
+	if resp, err = s.http.Get(s.buildLastURL(ssid, limit), nil, http.NewHeader("Accept", "application/binary")); err == nil {
+
+		// Decode the frame we received from the server
+		if frame, err := message.DecodeFrame(resp); err == nil {
+			for _, msg := range frame {
+				re <- msg.Payload
+			}
+			close(re)
+		}
+	}
+
+	// If there's an error, return a closed channel
+	if err != nil {
+		close(re)
+	}
+	return
 }
 
 // Close gracefully terminates the storage and ensures that every related
 // resource is properly disposed.
 func (s *HTTP) Close() error {
+	close(s.done)
 	return nil
+}
+
+// Store periodically flushes the pending queue.
+func (s *HTTP) store() {
+
+	// Encode the frame
+	s.Lock()
+	buffer, _ := s.frame.Encode()
+	s.frame = s.frame[:0]
+	s.Unlock()
+
+	// TODO: Make sure we don't lose messages if something happens
+	if _, err := s.http.Post(s.buildAppendURL(), buffer, nil, http.NewHeader("Content-Type", "application/binary")); err != nil {
+		logging.LogError("http storage", "storing messages", err)
+	}
+}
+
+// Builds an append URL
+func (s *HTTP) buildAppendURL() string {
+	return s.base + "msg/append"
+}
+
+// Builds last query URL
+func (s *HTTP) buildLastURL(ssid []uint32, limit int) string {
+	enc, _ := json.Marshal(ssid)
+	return s.base + fmt.Sprintf("msg/last?ssid=%s&n=%d", string(enc), limit)
 }

--- a/broker/storage/http_test.go
+++ b/broker/storage/http_test.go
@@ -13,3 +13,45 @@
 ************************************************************************************/
 
 package storage
+
+import (
+	"testing"
+
+	"github.com/emitter-io/emitter/broker/message"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestHTTP_Name(t *testing.T) {
+	s := NewHTTP()
+	assert.Equal(t, "http", s.Name())
+}
+
+func TestHTTP_Configure(t *testing.T) {
+	s := NewHTTP()
+	cfg := map[string]interface{}{
+		"interval": float64(100),
+		"url":      "http://127.0.0.1/",
+	}
+
+	err := s.Configure(cfg)
+	assert.NoError(t, err)
+
+	errClose := s.Close()
+	assert.NoError(t, errClose)
+}
+
+func TestHTTP_format(t *testing.T) {
+	s := NewHTTP()
+
+	assert.Equal(t, "msg/append", s.buildAppendURL())
+	assert.Equal(t, "msg/last?ssid=[1,2,3]&n=100", s.buildLastURL([]uint32{1, 2, 3}, 100))
+}
+
+func TestHTTP_Store(t *testing.T) {
+	s := NewHTTP()
+
+	s.Store(&message.Message{
+		Time: 0,
+	})
+	assert.Equal(t, 1, len(s.frame))
+}

--- a/broker/storage/http_test.go
+++ b/broker/storage/http_test.go
@@ -1,0 +1,15 @@
+/**********************************************************************************
+* Copyright (c) 2009-2017 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package storage

--- a/broker/storage/memory.go
+++ b/broker/storage/memory.go
@@ -48,6 +48,13 @@ type InMemory struct {
 	Query func(string, []byte) (message.Awaiter, error) // The cluster request function.
 }
 
+// NewInMemory creates a new in-memory storage.
+func NewInMemory(q func(string, []byte) (message.Awaiter, error)) *InMemory {
+	return &InMemory{
+		Query: q,
+	}
+}
+
 // Name returns the name of the provider.
 func (s *InMemory) Name() string {
 	return "inmemory"

--- a/broker/storage/memory_test.go
+++ b/broker/storage/memory_test.go
@@ -38,7 +38,7 @@ func newTestMemStore() *InMemory {
 }
 
 func TestInMemory_Name(t *testing.T) {
-	s := new(InMemory)
+	s := NewInMemory(nil)
 	assert.Equal(t, "inmemory", s.Name())
 }
 

--- a/broker/storage/storage_test.go
+++ b/broker/storage/storage_test.go
@@ -19,7 +19,7 @@ func testMessage(a, b, c uint32) *message.Message {
 }
 
 func TestNoop_Store(t *testing.T) {
-	s := new(Noop)
+	s := NewNoop()
 	err := s.Store(testMessage(1, 2, 3))
 	assert.NoError(t, err)
 }

--- a/network/address/address.go
+++ b/network/address/address.go
@@ -15,13 +15,14 @@
 package address
 
 import (
-	"github.com/emitter-io/emitter/logging"
 	"io/ioutil"
 	"math/rand"
 	"net"
 	"net/http"
 	"strings"
 	"time"
+
+	"github.com/emitter-io/emitter/logging"
 )
 
 var hardware uint64
@@ -47,21 +48,19 @@ func getExternal(urls ...string) (net.IP, bool) {
 	for _, url := range urls {
 		cli := http.Client{Timeout: time.Duration(5 * time.Second)}
 		res, err := cli.Get(url)
-		if err != nil {
-			continue
-		}
+		if err == nil {
 
-		// Read the response
-		defer res.Body.Close()
-		r, err := ioutil.ReadAll(res.Body)
-		if err != nil {
-			continue
-		}
+			// Read the response
+			defer res.Body.Close()
+			r, err := ioutil.ReadAll(res.Body)
+			if err == nil {
 
-		// Fix and parse
-		addr := strings.Replace(string(r), "\n", "", -1)
-		ip := net.ParseIP(addr)
-		return ip, ip != nil
+				// Fix and parse
+				addr := strings.Replace(string(r), "\n", "", -1)
+				ip := net.ParseIP(addr)
+				return ip, ip != nil
+			}
+		}
 	}
 
 	return nil, false

--- a/network/address/address_test.go
+++ b/network/address/address_test.go
@@ -8,5 +8,11 @@ import (
 
 func TestEncode(t *testing.T) {
 	assert.Equal(t, uint64(0x313233343536), encode([]byte("123456")))
+}
 
+func TestGlobals(t *testing.T) {
+	assert.NotEqual(t, "", External().String())
+	assert.NotEqual(t, Fingerprint(0), Hardware())
+	assert.NotEqual(t, "", Hardware().String())
+	assert.NotEqual(t, "", Hardware().Hex())
 }

--- a/network/http/http_test.go
+++ b/network/http/http_test.go
@@ -70,14 +70,20 @@ func TestPostGet(t *testing.T) {
 
 	{
 		output := new(testObject)
-		err := c.Get(s.URL, output)
+		_, err := c.Get(s.URL, output)
 		assert.NoError(t, err)
 		assert.EqualValues(t, expect, output)
 	}
 
 	{
+		body, err := c.Get(s.URL, nil)
+		assert.NoError(t, err)
+		assert.NotNil(t, body)
+	}
+
+	{
 		output := new(testObject)
-		err := c.Post(s.URL, jsonBody, output)
+		_, err := c.Post(s.URL, jsonBody, output)
 		assert.NoError(t, err)
 		assert.EqualValues(t, expect, output)
 	}

--- a/network/http/http_test.go
+++ b/network/http/http_test.go
@@ -1,12 +1,13 @@
 package http
 
 import (
+	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 	"time"
 
-	"encoding/json"
+	"github.com/emitter-io/emitter/utils"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -24,6 +25,7 @@ func TestNewClient(t *testing.T) {
 		{url: "http://google.com/123", ok: true},
 		{url: "google.com/123", ok: false},
 		{url: "235235", ok: false},
+		{url: "::", ok: false},
 	}
 
 	for _, tc := range tests {
@@ -38,11 +40,20 @@ func TestNewClient(t *testing.T) {
 }
 
 func (h *testHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
-	b, _ := json.Marshal(&testObject{
-		Field: "response",
-	})
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(b)
+	var response []byte
+	if r.Header.Get("Content-Type") == "application/binary" {
+		w.Header().Set("Content-Type", "application/binary")
+		response, _ = utils.Encode(&testObject{
+			Field: "response",
+		})
+	} else {
+		w.Header().Set("Content-Type", "application/json")
+		response, _ = json.Marshal(&testObject{
+			Field: "response",
+		})
+	}
+
+	w.Write(response)
 }
 
 func TestPostGet(t *testing.T) {
@@ -54,7 +65,7 @@ func TestPostGet(t *testing.T) {
 	jsonBody, _ := json.Marshal(body)
 
 	// Reuse the client
-	c, err := NewClient(s.URL, time.Second)
+	c, err := NewClient(s.URL, time.Second, NewHeader("Authorization", "123"))
 	assert.NoError(t, err)
 
 	{

--- a/network/http/mock.go
+++ b/network/http/mock.go
@@ -31,15 +31,15 @@ func NewMockClient() *MockClient {
 }
 
 // Get issues an HTTP Get on a specified URL and decodes the payload as JSON.
-func (mock *MockClient) Get(url string, output interface{}, headers ...HeaderValue) error {
+func (mock *MockClient) Get(url string, output interface{}, headers ...HeaderValue) ([]byte, error) {
 	mockArgs := mock.Called(url, output, headers)
-	return mockArgs.Error(0)
+	return mockArgs.Get(0).([]byte), mockArgs.Error(1)
 }
 
 // Post is a utility function which marshals and issues an HTTP post on a specified URL.
-func (mock *MockClient) Post(url string, body []byte, output interface{}, headers ...HeaderValue) error {
+func (mock *MockClient) Post(url string, body []byte, output interface{}, headers ...HeaderValue) ([]byte, error) {
 	mockArgs := mock.Called(url, body, output, headers)
-	return mockArgs.Error(0)
+	return mockArgs.Get(0).([]byte), mockArgs.Error(1)
 }
 
 // PostJSON is a helper function which posts a JSON body with an appropriate content type.

--- a/network/http/mock_test.go
+++ b/network/http/mock_test.go
@@ -16,12 +16,14 @@ func TestMock(t *testing.T) {
 	out := new(testObject)
 
 	// Get(url string, output interface{}, headers ...HeaderValue) error
-	c.On("Get", url, mock.Anything, mock.Anything).Return(nil).Once()
-	assert.Nil(t, c.Get(url, out))
+	c.On("Get", url, mock.Anything, mock.Anything).Return([]byte{}, nil).Once()
+	_, e1 := c.Get(url, out)
+	assert.Nil(t, e1)
 
 	// Post(url string, body []byte, output interface{}, headers ...HeaderValue) error
-	c.On("Post", url, mock.Anything, mock.Anything, mock.Anything).Return(nil).Once()
-	assert.Nil(t, c.Post(url, buf, out))
+	c.On("Post", url, mock.Anything, mock.Anything, mock.Anything).Return([]byte{}, nil).Once()
+	_, e2 := c.Post(url, buf, out)
+	assert.Nil(t, e2)
 
 	// PostJSON(url string, body interface{}, output interface{}) (err error)
 	c.On("PostJSON", url, mock.Anything, mock.Anything).Return(nil).Once()

--- a/security/contract.go
+++ b/security/contract.go
@@ -179,7 +179,7 @@ func (p *HTTPContractProvider) Get(id uint32) (Contract, bool) {
 
 func (p *HTTPContractProvider) fetchContract(id uint32) (*contract, bool) {
 	c := new(contract)
-	err := p.http.Get(fmt.Sprintf("%s%d", p.url, id), c)
+	_, err := p.http.Get(fmt.Sprintf("%s%d", p.url, id), c)
 	if err != nil {
 		logging.LogError("contract", "fetching http contract", err)
 		return nil, false

--- a/security/contract_test.go
+++ b/security/contract_test.go
@@ -94,9 +94,9 @@ func TestHTTPContractProvider_Get(t *testing.T) {
 	h.On("Get", "1", mock.Anything, mock.Anything).Run(func(args mock.Arguments) {
 		output := args.Get(1).(interface{})
 		json.Unmarshal([]byte(`{"id": 1}`), output)
-	}).Return(nil)
+	}).Return([]byte{}, nil)
 
-	h.On("Get", "2", mock.Anything, mock.Anything).Return(nil)
+	h.On("Get", "2", mock.Anything, mock.Anything).Return([]byte{}, nil)
 
 	p, _ := testNewHTTPContractProvider()
 	p.http = h

--- a/security/usage/metering.go
+++ b/security/usage/metering.go
@@ -54,7 +54,7 @@ var _ Metering = new(HTTPStorage)
 
 // HTTPStorage represents a usage storage which posts meters over HTTP.
 type HTTPStorage struct {
-	counters sync.Map    // The counters map.
+	counters *sync.Map   // The counters map.
 	url      string      // The url to post to.
 	http     http.Client // The http client to use.
 	done     chan bool   // The closing channel.
@@ -63,7 +63,8 @@ type HTTPStorage struct {
 // NewHTTP creates a new HTTP storage
 func NewHTTP() *HTTPStorage {
 	return &HTTPStorage{
-		done: make(chan bool),
+		counters: new(sync.Map),
+		done:     make(chan bool),
 	}
 }
 

--- a/security/usage/metering_test.go
+++ b/security/usage/metering_test.go
@@ -33,6 +33,7 @@ func TestNoop_Get(t *testing.T) {
 func TestHTTP_New(t *testing.T) {
 	s := NewHTTP()
 	assert.NotNil(t, s.counters)
+
 }
 
 func TestHTTP_Name(t *testing.T) {
@@ -59,7 +60,6 @@ func TestHTTP_Configure(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Equal(t, "http://localhost/test", s.url)
 	assert.NotNil(t, s.http)
-
 }
 
 func TestHTTP_Store(t *testing.T) {


### PR DESCRIPTION
Adding an experimental implementation of HTTP-based message storage. This currently supports only `binary` encoding of message frames, but may be extended to `JSON` in future.