### PR TITLE
Feature: channel-specific keys and matching, retro-compatible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
         "-s"
     ],
     "go.coverOnSave": true,
-    "go.coverageOptions":"showCoveredCodeOnly",
+    "go.coverageOptions":"showUncoveredCodeOnly",
 
       
     "TodoParser":

--- a/broker/handlers_dto.go
+++ b/broker/handlers_dto.go
@@ -27,6 +27,8 @@ var (
 	ErrNotFound        = &EventError{Status: 404, Message: "The resource requested does not exist."}
 	ErrServerError     = &EventError{Status: 500, Message: "An unexpected condition was encountered and no more specific message is suitable."}
 	ErrNotImplemented  = &EventError{Status: 501, Message: "The server either does not recognize the request method, or it lacks the ability to fulfill the request."}
+	ErrTargetInvalid   = &EventError{Status: 400, Message: "Channel should end with `/` for strict types or `/#` for wildcards."}
+	ErrTargetTooLong   = &EventError{Status: 400, Message: "Channel can not have more than 15 parts."}
 )
 
 // ------------------------------------------------------------------------------------

--- a/security/crypto.go
+++ b/security/crypto.go
@@ -22,8 +22,6 @@ import (
 	"math/big"
 	"strconv"
 	"time"
-
-	"github.com/emitter-io/emitter/utils"
 )
 
 const (
@@ -144,8 +142,11 @@ func (c *Cipher) GenerateKey(masterKey Key, channel string, permissions uint32, 
 	key.SetContract(masterKey.Contract())
 	key.SetSignature(masterKey.Signature())
 	key.SetPermissions(permissions)
-	key.SetTarget(utils.GetHash([]byte(channel)))
 	key.SetExpires(expires)
+	if err := key.SetTarget(channel); err != nil {
+		return "", err
+	}
+
 	return c.EncryptKey(key)
 }
 

--- a/security/crypto_test.go
+++ b/security/crypto_test.go
@@ -168,8 +168,21 @@ func TestGenerateKey(t *testing.T) {
 	license, _ := ParseLicense("pLcaYvemMQOZR9o9sa5COWztxfAAAAAAAAAAAAAAAAI")
 	cipher, _ := license.Cipher()
 	masterKey, _ := cipher.DecryptKey([]byte("xEbaDPaICEwVhgdnl2rg_1DWi_MAg_3B"))
-	key, err := cipher.GenerateKey(masterKey, "article1", AllowRead, time.Unix(0, 0), 1)
 
-	assert.Nil(t, err)
-	assert.Equal(t, "jhdrak0aHbZFY64rXoNHMXdW3JwwgtNw", key)
+	tests := []struct {
+		channel  string
+		expected string
+		err      bool
+	}{
+		{channel: "article1", err: true},
+		{channel: "article1/", expected: "jhdrak0aHbbK6TbmyA391n2FucwUj7Q2"},
+	}
+
+	for _, tc := range tests {
+		key, err := cipher.GenerateKey(masterKey, tc.channel, AllowRead, time.Unix(0, 0), 1)
+		assert.Equal(t, tc.err, err != nil)
+		if !tc.err {
+			assert.Equal(t, tc.expected, key)
+		}
+	}
 }

--- a/security/key_test.go
+++ b/security/key_test.go
@@ -12,6 +12,41 @@ func TestKeyIsEmpty(t *testing.T) {
 	assert.True(t, true, key.IsEmpty())
 }
 
+func validateChannel(k Key, c string) bool {
+	return k.ValidateChannel(&Channel{Channel: []byte(c)})
+}
+
+func TestKey_New(t *testing.T) {
+	key := Key(make([]byte, 24))
+
+	// Test exact channel
+	key.SetTarget("a/b/c/")
+	assert.False(t, validateChannel(key, "a/b/"))
+	assert.True(t, validateChannel(key, "a/b/c/"))
+	assert.False(t, validateChannel(key, "a/b/c/d/"))
+
+	// Test exact channel with wildcard
+	key.SetTarget("a/+/c/")
+	assert.True(t, validateChannel(key, "a/b/c/"))
+	assert.True(t, validateChannel(key, "a/c/c/"))
+	assert.True(t, validateChannel(key, "a/d/c/"))
+	assert.True(t, validateChannel(key, "a/+/c/"))
+	assert.False(t, validateChannel(key, "a/b/+/"))
+
+	// Test open channel
+	key.SetTarget("a/b/c/#/")
+	assert.False(t, validateChannel(key, "a/b/"))
+	assert.True(t, validateChannel(key, "a/b/c/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/e/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/+/f/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/+/f/#/"))
+
+	assert.Nil(t, key.SetTarget("1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/"))
+	assert.Nil(t, key.SetTarget("1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/#/"))
+	assert.NotNil(t, key.SetTarget("1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/"))
+}
+
 func TestKey(t *testing.T) {
 	key := Key(make([]byte, 24))
 
@@ -20,7 +55,7 @@ func TestKey(t *testing.T) {
 	key.SetContract(123)
 	key.SetSignature(777)
 	key.SetPermissions(AllowReadWrite)
-	key.SetTarget(56789)
+	key.SetTarget("a/b/c/")
 	key.SetExpires(time.Unix(1497683272, 0).UTC())
 
 	assert.Equal(t, uint16(999), key.Salt())
@@ -28,7 +63,6 @@ func TestKey(t *testing.T) {
 	assert.Equal(t, uint32(123), key.Contract())
 	assert.Equal(t, uint32(777), key.Signature())
 	assert.Equal(t, AllowReadWrite, key.Permissions())
-	assert.Equal(t, uint32(56789), key.Target())
 	assert.Equal(t, time.Unix(1497683272, 0).UTC(), key.Expires())
 
 	key.SetExpires(time.Unix(0, 0))


### PR DESCRIPTION
Based on the idea https://github.com/emitter-io/emitter/issues/76 proposed by @alaingilbert and his proof of concept, this PR implements the channel-specific keys while maintaining retro-compatibility with generated keys.

There's a slight change in the way keys are going to be generated, couple of new errors will be propagated to the end-user.