### PR TITLE
Feature: channel-specific keys and matching, retro-compatible

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -16,7 +16,7 @@
         "-s"
     ],
     "go.coverOnSave": true,
-    "go.coverageOptions":"showCoveredCodeOnly",
+    "go.coverageOptions":"showUncoveredCodeOnly",
 
       
     "TodoParser":

--- a/broker/handlers_dto.go
+++ b/broker/handlers_dto.go
@@ -27,6 +27,8 @@ var (
 	ErrNotFound        = &EventError{Status: 404, Message: "The resource requested does not exist."}
 	ErrServerError     = &EventError{Status: 500, Message: "An unexpected condition was encountered and no more specific message is suitable."}
 	ErrNotImplemented  = &EventError{Status: 501, Message: "The server either does not recognize the request method, or it lacks the ability to fulfill the request."}
+	ErrTargetInvalid   = &EventError{Status: 400, Message: "Channel should end with `/` for strict types or `/#/` for wildcards."}
+	ErrTargetTooLong   = &EventError{Status: 400, Message: "Channel can not have more than 23 parts."}
 )
 
 // ------------------------------------------------------------------------------------

--- a/security/crypto.go
+++ b/security/crypto.go
@@ -22,8 +22,6 @@ import (
 	"math/big"
 	"strconv"
 	"time"
-
-	"github.com/emitter-io/emitter/utils"
 )
 
 const (
@@ -144,8 +142,11 @@ func (c *Cipher) GenerateKey(masterKey Key, channel string, permissions uint32, 
 	key.SetContract(masterKey.Contract())
 	key.SetSignature(masterKey.Signature())
 	key.SetPermissions(permissions)
-	key.SetTarget(utils.GetHash([]byte(channel)))
 	key.SetExpires(expires)
+	if err := key.SetTarget(channel); err != nil {
+		return "", err
+	}
+
 	return c.EncryptKey(key)
 }
 

--- a/security/crypto_test.go
+++ b/security/crypto_test.go
@@ -168,8 +168,21 @@ func TestGenerateKey(t *testing.T) {
 	license, _ := ParseLicense("pLcaYvemMQOZR9o9sa5COWztxfAAAAAAAAAAAAAAAAI")
 	cipher, _ := license.Cipher()
 	masterKey, _ := cipher.DecryptKey([]byte("xEbaDPaICEwVhgdnl2rg_1DWi_MAg_3B"))
-	key, err := cipher.GenerateKey(masterKey, "article1", AllowRead, time.Unix(0, 0), 1)
 
-	assert.Nil(t, err)
-	assert.Equal(t, "jhdrak0aHbZFY64rXoNHMXdW3JwwgtNw", key)
+	tests := []struct {
+		channel  string
+		expected string
+		err      bool
+	}{
+		{channel: "article1", err: true},
+		{channel: "article1/", expected: "jhdrak0aHbbK6TbmyA391n2FucwUj7Q2"},
+	}
+
+	for _, tc := range tests {
+		key, err := cipher.GenerateKey(masterKey, tc.channel, AllowRead, time.Unix(0, 0), 1)
+		assert.Equal(t, tc.err, err != nil)
+		if !tc.err {
+			assert.Equal(t, tc.expected, key)
+		}
+	}
 }

--- a/security/key.go
+++ b/security/key.go
@@ -15,7 +15,11 @@
 package security
 
 import (
+	"errors"
+	"strings"
 	"time"
+
+	"github.com/emitter-io/emitter/utils"
 )
 
 // Access types for a security key.
@@ -29,6 +33,12 @@ const (
 	AllowPresence  = uint32(1 << 5)         // Key should be allowed to query the presence on the target channel.
 	AllowReadWrite = AllowRead | AllowWrite // Key should be allowed to read and write to the target channel.
 	AllowStoreLoad = AllowStore | AllowLoad // Key should be allowed to read and write the message history.
+)
+
+// Key errors
+var (
+	ErrTargetInvalid = errors.New("channel should end with `/` for strict types or `/#/` for multi level wildcard")
+	ErrTargetTooLong = errors.New("channel can not have more than 23 parts")
 )
 
 // Key represents a security key.
@@ -89,28 +99,112 @@ func (k Key) SetSignature(value uint32) {
 
 // Permissions gets the permission flags.
 func (k Key) Permissions() uint32 {
-	return uint32(k[12])<<24 | uint32(k[13])<<16 | uint32(k[14])<<8 | uint32(k[15])
+	return uint32(k[15])
 }
 
 // SetPermissions sets the permission flags.
 func (k Key) SetPermissions(value uint32) {
-	k[12] = byte(value >> 24)
-	k[13] = byte(value >> 16)
-	k[14] = byte(value >> 8)
 	k[15] = byte(value)
 }
 
-// Target gets the target for the key.
-func (k Key) Target() uint32 {
-	return uint32(k[16])<<24 | uint32(k[17])<<16 | uint32(k[18])<<8 | uint32(k[19])
+// ValidateChannel validates the channel string.
+func (k Key) ValidateChannel(ch *Channel) bool {
+
+	// Bytes 16-17-18-19 contains target hash
+	target := uint32(k[16])<<24 | uint32(k[17])<<16 | uint32(k[18])<<8 | uint32(k[19])
+	targetPath := uint32(k[12])<<16 | uint32(k[13])<<8 | uint32(k[14])
+
+	// Retro-compatibility: if there's no depth specified we default to a single-level validation
+	if targetPath == 0 {
+		return target == ch.Target()
+	}
+
+	channel := string(ch.Channel)
+	channel = strings.TrimRight(channel, "/")
+	parts := strings.Split(channel, "/")
+	wc := parts[len(parts)-1] == "#"
+	if wc {
+		parts = parts[0 : len(parts)-1]
+	}
+
+	maxDepth := 0
+
+	for i := 0; i < 23; i++ {
+		if ((targetPath >> (22 - uint32(i))) & 1) == 1 {
+			maxDepth = i
+		}
+	}
+	maxDepth++
+
+	// Get the first bit, whether the key is the exact match or not
+	keyIsExactTarget := ((targetPath >> 23) & 1) == 1
+	if len(parts) < maxDepth || (keyIsExactTarget && len(parts) != maxDepth) {
+		return false
+	}
+
+	for idx, part := range parts {
+		if part == "+" {
+			if ((targetPath >> (22 - uint32(idx))) & 1) == 1 {
+				return false
+			}
+		}
+		if ((targetPath >> (22 - uint32(idx))) & 1) == 0 {
+			parts[idx] = "+"
+		}
+	}
+
+	newChannel := strings.Join(parts[0:maxDepth], "/")
+
+	h := utils.GetHash([]byte(newChannel))
+
+	return h == target
 }
 
-// SetTarget sets the target for the key.
-func (k Key) SetTarget(value uint32) {
+// SetTarget sets the target channel for the key.
+func (k Key) SetTarget(channel string) error {
+	if !strings.HasSuffix(channel, "/") {
+		return ErrTargetInvalid
+	}
+
+	// Get all of the parts for the target channel
+	// History: https://github.com/emitter-io/emitter/issues/76
+	parts := strings.Split(strings.TrimRight(channel, "/"), "/")
+	wildcard := parts[len(parts)-1] == "#"
+
+	// 1st bit is 0 for wildcard, 1 for strict type
+	bitPath := uint32(1 << 23)
+	if wildcard {
+		parts = parts[0 : len(parts)-1]
+		bitPath = 0
+	}
+
+	// Perform some validation
+	if len(parts) > 23 {
+		return ErrTargetTooLong
+	}
+
+	// Encode all of the parts
+	for idx, part := range parts {
+		if part != "+" && part != "#" {
+			bitPath |= uint32(1 << (22 - uint16(idx)))
+		}
+	}
+
+	// Create a new channel and get the hash for this channel
+	newChannel := strings.Join(parts, "/")
+	value := utils.GetHash([]byte(newChannel))
+
+	// Set the bit path
+	k[12] = byte(bitPath >> 16)
+	k[13] = byte(bitPath >> 8)
+	k[14] = byte(bitPath)
+
+	// Set the hash of the target
 	k[16] = byte(value >> 24)
 	k[17] = byte(value >> 16)
 	k[18] = byte(value >> 8)
 	k[19] = byte(value)
+	return nil
 }
 
 // Expires gets the expiration date for the key.

--- a/security/key_test.go
+++ b/security/key_test.go
@@ -12,6 +12,54 @@ func TestKeyIsEmpty(t *testing.T) {
 	assert.True(t, true, key.IsEmpty())
 }
 
+func validateChannel(k Key, c string) bool {
+	return k.ValidateChannel(&Channel{Channel: []byte(c)})
+}
+
+func TestKey_New(t *testing.T) {
+	key := Key(make([]byte, 24))
+
+	// Test retro-compatibility
+	// A key with bytes 12-13-14 set to 0 will only compare the first part of the channel.
+	key.SetTarget("a/")
+	key[12] = 0
+	key[13] = 0
+	key[14] = 0
+	assert.True(t, key.ValidateChannel(ParseChannel([]byte(string(key)+"/a/"))))
+	assert.True(t, key.ValidateChannel(ParseChannel([]byte(string(key)+"/a/b/"))))
+	assert.True(t, key.ValidateChannel(ParseChannel([]byte(string(key)+"/a/b/c/"))))
+	assert.True(t, key.ValidateChannel(ParseChannel([]byte(string(key)+"/a/+/c/"))))
+	assert.False(t, key.ValidateChannel(ParseChannel([]byte(string(key)+"/b/"))))
+
+	// Test exact channel
+	key.SetTarget("a/b/c/")
+	assert.False(t, validateChannel(key, "a/b/"))
+	assert.True(t, validateChannel(key, "a/b/c/"))
+	assert.False(t, validateChannel(key, "a/b/c/d/"))
+
+	// Test exact channel with wildcard
+	key.SetTarget("a/+/c/")
+	assert.True(t, validateChannel(key, "a/b/c/"))
+	assert.True(t, validateChannel(key, "a/c/c/"))
+	assert.True(t, validateChannel(key, "a/d/c/"))
+	assert.True(t, validateChannel(key, "a/+/c/"))
+	assert.False(t, validateChannel(key, "a/b/+/"))
+
+	// Test open channel
+	key.SetTarget("a/b/c/#/")
+	assert.False(t, validateChannel(key, "a/b/"))
+	assert.True(t, validateChannel(key, "a/b/c/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/e/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/+/f/"))
+	assert.True(t, validateChannel(key, "a/b/c/d/+/f/#/"))
+
+	// Test ErrTargetTooLong
+	assert.Nil(t, key.SetTarget("1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/"))
+	assert.Nil(t, key.SetTarget("1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/#/"))
+	assert.Equal(t, ErrTargetTooLong, key.SetTarget("1/2/3/4/5/6/7/8/9/10/11/12/13/14/15/16/17/18/19/20/21/22/23/24/"))
+}
+
 func TestKey(t *testing.T) {
 	key := Key(make([]byte, 24))
 
@@ -20,7 +68,7 @@ func TestKey(t *testing.T) {
 	key.SetContract(123)
 	key.SetSignature(777)
 	key.SetPermissions(AllowReadWrite)
-	key.SetTarget(56789)
+	key.SetTarget("a/b/c/")
 	key.SetExpires(time.Unix(1497683272, 0).UTC())
 
 	assert.Equal(t, uint16(999), key.Salt())
@@ -28,7 +76,6 @@ func TestKey(t *testing.T) {
 	assert.Equal(t, uint32(123), key.Contract())
 	assert.Equal(t, uint32(777), key.Signature())
 	assert.Equal(t, AllowReadWrite, key.Permissions())
-	assert.Equal(t, uint32(56789), key.Target())
 	assert.Equal(t, time.Unix(1497683272, 0).UTC(), key.Expires())
 
 	key.SetExpires(time.Unix(0, 0))


### PR DESCRIPTION
Hi guys.

I really don't want to be a pain...
but I would like to get the contribution for this feature in the project if it doesn't bother you too much.

So this PR is basically a cherry-pick of your [other PR](https://github.com/emitter-io/emitter/pull/81).
The main difference is that I also use the byte 14 (that was unused in your PR) so we can have 23 levels depth channels.