### PR TITLE
Update github.com/emitter-io/config vendor to latest version

### DIFF
--- a/vendor/github.com/emitter-io/config/config.go
+++ b/vendor/github.com/emitter-io/config/config.go
@@ -9,7 +9,6 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"plugin"
 	"reflect"
 	"strconv"
 	"strings"
@@ -123,38 +122,7 @@ func (c *ProviderConfig) Load(builtins ...Provider) (Provider, error) {
 		}
 	}
 
-	// Attempt to load a plugin provider
-	p, err := plugin.Open(resolvePath(c.Provider))
-	if err != nil {
-		return nil, errors.New("The provider plugin '" + c.Provider + "' could not be opened. " + err.Error())
-	}
-
-	// Get the symbol
-	sym, err := p.Lookup("New")
-	if err != nil {
-		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
-	}
-
-	// Resolve the
-	pFactory, validFunc := sym.(*func() interface{})
-	if !validFunc {
-		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
-	}
-
-	// Construct the provider
-	provider, validProv := ((*pFactory)()).(Provider)
-	if !validProv {
-		return nil, errors.New("The provider '" + c.Provider + "' does not implement 'Provider'")
-	}
-
-	// Configure the provider
-	err = provider.Configure(c.Config)
-	if err != nil {
-		return nil, errors.New("The provider '" + c.Provider + "' could not be configured")
-	}
-
-	// Succesfully opened and configured a provider
-	return provider, nil
+	return c.LoadPlugin()
 }
 
 // LoadProvider loads a provider from the configuration or panics if the configuration is

--- a/vendor/github.com/emitter-io/config/config_plugin.go
+++ b/vendor/github.com/emitter-io/config/config_plugin.go
@@ -1,0 +1,43 @@
+// +build !darwin
+
+package config
+
+import (
+	"errors"
+	"plugin"
+)
+
+func (c *ProviderConfig) LoadPlugin() (Provider, error) {
+	// Attempt to load a plugin provider
+	p, err := plugin.Open(resolvePath(c.Provider))
+	if err != nil {
+		return nil, errors.New("The provider plugin '" + c.Provider + "' could not be opened. " + err.Error())
+	}
+
+	// Get the symbol
+	sym, err := p.Lookup("New")
+	if err != nil {
+		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
+	}
+
+	// Resolve the
+	pFactory, validFunc := sym.(*func() interface{})
+	if !validFunc {
+		return nil, errors.New("The provider '" + c.Provider + "' does not contain 'func New() interface{}' symbol")
+	}
+
+	// Construct the provider
+	provider, validProv := ((*pFactory)()).(Provider)
+	if !validProv {
+		return nil, errors.New("The provider '" + c.Provider + "' does not implement 'Provider'")
+	}
+
+	// Configure the provider
+	err = provider.Configure(c.Config)
+	if err != nil {
+		return nil, errors.New("The provider '" + c.Provider + "' could not be configured")
+	}
+
+	// Succesfully opened and configured a provider
+	return provider, nil
+}

--- a/vendor/github.com/emitter-io/config/config_plugin_darwin.go
+++ b/vendor/github.com/emitter-io/config/config_plugin_darwin.go
@@ -1,0 +1,7 @@
+package config
+
+import "errors"
+
+func (c *ProviderConfig) LoadPlugin() (Provider, error) {
+	return nil, errors.New("The provider plugin '" + c.Provider + "' could not be opened. Plugin not supported on darwin.")
+}

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -27,10 +27,10 @@
 			"revisionTime": "2017-11-29T05:14:37Z"
 		},
 		{
-			"checksumSHA1": "fMDpZXOkkw+kpmx4f5MdYGf1wWo=",
+			"checksumSHA1": "+9BgM2R+6mn6uhDhcPAT89tuItY=",
 			"path": "github.com/emitter-io/config",
-			"revision": "e45052429f4ed5b0866761e482ce94e90640cfec",
-			"revisionTime": "2017-12-17T01:41:23Z"
+			"revision": "4e4d0bfcc995bd4c956c67d9a8a0bb74d7d53cc1",
+			"revisionTime": "2018-02-13T06:24:23Z"
 		},
 		{
 			"checksumSHA1": "OV+/R43DDDJ/Gxrx9oQob/K7sL0=",


### PR DESCRIPTION
Get rid of the following warning on OSX.
```
ld: warning: PIE disabled. Absolute addressing (perhaps -mdynamic-no-pic) not allowed in code signed PIE, but used in type..eqfunc.[106]string from /var/folders/hz/nqhk5_3n4v9_rkgjdmqk5k5w0000gn/T/go-link-728052133/go.o. To fix this warning, don't compile with -mdynamic-no-pic or link with -Wl,-no_pie
```