### PR TITLE
Feature/fix key validation

### DIFF
--- a/security/key.go
+++ b/security/key.go
@@ -151,12 +151,11 @@ func (k Key) ValidateChannel(ch *Channel) bool {
 	}
 
 	for idx, part := range parts {
-		if part == "+" {
-			if ((targetPath >> (22 - uint32(idx))) & 1) == 1 {
+		if ((targetPath >> (22 - uint32(idx))) & 1) == 1 {
+			if part == "+" {
 				return false
 			}
-		}
-		if ((targetPath >> (22 - uint32(idx))) & 1) == 0 {
+		} else {
 			parts[idx] = "+"
 		}
 	}

--- a/security/key.go
+++ b/security/key.go
@@ -138,6 +138,12 @@ func (k Key) ValidateChannel(ch *Channel) bool {
 		}
 	}
 
+	// If no depth defined, all the parts in key target were wildcards (+)
+	// We need to compare the key hash with the whole channel we received.
+	if maxDepth == 0 {
+		maxDepth = len(parts)
+	}
+
 	// Get the first bit, whether the key is the exact match or not
 	keyIsExactTarget := ((targetPath >> 23) & 1) == 1
 	if len(parts) < maxDepth || (keyIsExactTarget && len(parts) != maxDepth) {

--- a/security/key.go
+++ b/security/key.go
@@ -128,13 +128,12 @@ func (k Key) ValidateChannel(ch *Channel) bool {
 	}
 
 	maxDepth := 0
-
-	for i := 0; i < 23; i++ {
-		if ((targetPath >> (22 - uint32(i))) & 1) == 1 {
-			maxDepth = i
+	for i := uint32(0); i < 23; i++ {
+		if ((targetPath >> i) & 1) == 1 {
+			maxDepth = 23 - int(i)
+			break
 		}
 	}
-	maxDepth++
 
 	// Get the first bit, whether the key is the exact match or not
 	keyIsExactTarget := ((targetPath >> 23) & 1) == 1

--- a/security/key.go
+++ b/security/key.go
@@ -116,6 +116,9 @@ func (k Key) ValidateChannel(ch *Channel) bool {
 
 	// Retro-compatibility: if there's no depth specified we default to a single-level validation
 	if targetPath == 0 {
+		if target == 1325880984 { // Key target was "#/" (1325880984 == hash(""))
+			return true
+		}
 		return target == ch.Target()
 	}
 

--- a/security/key_test.go
+++ b/security/key_test.go
@@ -46,6 +46,12 @@ func TestKey_New(t *testing.T) {
 	assert.False(t, validateChannel(key, "a/b/+/"))
 
 	// Test open channel
+	key.SetTarget("#/")
+	assert.True(t, validateChannel(key, "/"))
+	assert.True(t, validateChannel(key, "a/"))
+	assert.True(t, validateChannel(key, "a/b/"))
+	assert.True(t, validateChannel(key, "a/b/c/"))
+
 	key.SetTarget("a/b/c/#/")
 	assert.False(t, validateChannel(key, "a/b/"))
 	assert.True(t, validateChannel(key, "a/b/c/"))

--- a/security/key_test.go
+++ b/security/key_test.go
@@ -45,6 +45,27 @@ func TestKey_New(t *testing.T) {
 	assert.True(t, validateChannel(key, "a/+/c/"))
 	assert.False(t, validateChannel(key, "a/b/+/"))
 
+	key.SetTarget("+/")
+	assert.True(t, validateChannel(key, "/"))
+	assert.True(t, validateChannel(key, "a/"))
+	assert.False(t, validateChannel(key, "a/b/"))
+	assert.False(t, validateChannel(key, "a/b/c/"))
+
+	key.SetTarget("+/+/")
+	assert.False(t, validateChannel(key, "/"))
+	assert.False(t, validateChannel(key, "a/"))
+	assert.True(t, validateChannel(key, "a/b/"))
+	assert.False(t, validateChannel(key, "a/b/c/"))
+	assert.True(t, validateChannel(key, "a/+/"))
+	assert.True(t, validateChannel(key, "+/b/"))
+	assert.True(t, validateChannel(key, "+/+/"))
+
+	key.SetTarget("+/+/+/")
+	assert.False(t, validateChannel(key, "/"))
+	assert.False(t, validateChannel(key, "a/"))
+	assert.False(t, validateChannel(key, "a/b/"))
+	assert.True(t, validateChannel(key, "a/b/c/"))
+
 	// Test open channel
 	key.SetTarget("#/")
 	assert.True(t, validateChannel(key, "/"))


### PR DESCRIPTION
Hello,
I came across some edge cases in the per channel auth feature.

This pull request includes 4 commits that can be reviewed individually.
- The first one is just a better algorithm to find the least significant bit set.
- Second, Fix the case where you want a key that is valid for all channels (`#/`)
- Third, Fix the case for keys that only contains wildcards (IE: `+/+/+/`)
- Fourth, just remove some complexity from the code, making it a bit easier to read.