### PR TITLE
Support for letsencrypt http-1 validation

### DIFF
--- a/broker/service.go
+++ b/broker/service.go
@@ -177,7 +177,14 @@ func (s *Service) Listen() (err error) {
 
 	// Setup the listeners on both default and a secure addresses
 	s.listen(s.Config.ListenAddr, nil)
-	if tls, ok := s.Config.Certificate(); ok {
+	if tls, tlsValidator, ok := s.Config.Certificate(); ok {
+
+		// If we need to validate certificate, spin up a listener on port 80
+		// More info: https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188
+		if tlsValidator != nil {
+			go http.ListenAndServe(":80", tlsValidator)
+		}
+
 		s.listen(s.Config.TLS.ListenAddr, tls)
 	}
 

--- a/config/config.go
+++ b/config/config.go
@@ -17,6 +17,7 @@ package config
 import (
 	"crypto/tls"
 	"net"
+	"net/http"
 	"strings"
 
 	cfg "github.com/emitter-io/config"
@@ -76,17 +77,18 @@ func (c *Config) Vault() *cfg.VaultConfig {
 }
 
 // Certificate returns TLS configuration.
-func (c *Config) Certificate() (tls *tls.Config, ok bool) {
+func (c *Config) Certificate() (tls *tls.Config, tlsValidator http.Handler, ok bool) {
 	if c.TLS != nil {
 
 		// Attempt to use Vault cache
 		cache, err := cfg.NewVaultCache(VaultUser, c)
 		if err != nil {
+			logging.LogError("tls", "vault cache init", err)
 			logging.LogAction("tls", "unable to setup Vault certificate cache, using disk")
 		}
 
 		// Load from TLS
-		tls, err = c.TLS.Load(cache)
+		tls, tlsValidator, err = c.TLS.Load(cache)
 		ok = err == nil
 	}
 	return

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -11,7 +11,7 @@ func Test_NewDefaut(t *testing.T) {
 	assert.Equal(t, ":8080", c.ListenAddr)
 	assert.Nil(t, c.Vault())
 
-	tls, ok := c.Certificate()
+	tls, _, ok := c.Certificate()
 	assert.Nil(t, tls)
 	assert.False(t, ok)
 }

--- a/vendor/github.com/emitter-io/config/http.go
+++ b/vendor/github.com/emitter-io/config/http.go
@@ -22,8 +22,8 @@ type httpHeader struct {
 	Value  string
 }
 
-// newHttpHeader builds an HTTP header with a value.
-func newHttpHeader(header, value string) httpHeader {
+// newHTTPHeader builds an HTTP header with a value.
+func newHTTPHeader(header, value string) httpHeader {
 	return httpHeader{Header: header, Value: value}
 }
 

--- a/vendor/github.com/emitter-io/config/vault.go
+++ b/vendor/github.com/emitter-io/config/vault.go
@@ -74,7 +74,7 @@ func (c *VaultClient) WriteSecret(secretName string, value string) error {
 func (c *VaultClient) get(url string) (output *vaultSecret, err error) {
 	var headers []httpHeader
 	if c.IsAuthenticated() {
-		headers = append(headers, newHttpHeader("X-Vault-Token", c.token))
+		headers = append(headers, newHTTPHeader("X-Vault-Token", c.token))
 	}
 
 	// Issue the HTTP Get
@@ -87,7 +87,7 @@ func (c *VaultClient) get(url string) (output *vaultSecret, err error) {
 func (c *VaultClient) post(url string, body interface{}) (output *vaultSecret, err error) {
 	var headers []httpHeader
 	if c.IsAuthenticated() {
-		headers = append(headers, newHttpHeader("X-Vault-Token", c.token))
+		headers = append(headers, newHTTPHeader("X-Vault-Token", c.token))
 	}
 
 	// Issue the HTTP Post

--- a/vendor/github.com/gorilla/websocket/client.go
+++ b/vendor/github.com/gorilla/websocket/client.go
@@ -201,7 +201,7 @@ func (d *Dialer) Dial(urlStr string, requestHeader http.Header) (*Conn, *http.Re
 	}
 
 	if d.EnableCompression {
-		req.Header.Set("Sec-Websocket-Extensions", "permessage-deflate; server_no_context_takeover; client_no_context_takeover")
+		req.Header["Sec-WebSocket-Extensions"] = []string{"permessage-deflate; server_no_context_takeover; client_no_context_takeover"}
 	}
 
 	var deadline time.Time

--- a/vendor/github.com/gorilla/websocket/proxy.go
+++ b/vendor/github.com/gorilla/websocket/proxy.go
@@ -14,7 +14,7 @@ import (
 	"strings"
 )
 
-type netDialerFunc func(netowrk, addr string) (net.Conn, error)
+type netDialerFunc func(network, addr string) (net.Conn, error)
 
 func (fn netDialerFunc) Dial(network, addr string) (net.Conn, error) {
 	return fn(network, addr)

--- a/vendor/github.com/gorilla/websocket/server.go
+++ b/vendor/github.com/gorilla/websocket/server.go
@@ -103,7 +103,7 @@ func (u *Upgrader) selectSubprotocol(r *http.Request, responseHeader http.Header
 //
 // The responseHeader is included in the response to the client's upgrade
 // request. Use the responseHeader to specify cookies (Set-Cookie) and the
-// application negotiated subprotocol (Sec-Websocket-Protocol).
+// application negotiated subprotocol (Sec-WebSocket-Protocol).
 //
 // If the upgrade fails, then Upgrade replies to the client with an HTTP error
 // response.
@@ -127,7 +127,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	}
 
 	if _, ok := responseHeader["Sec-Websocket-Extensions"]; ok {
-		return u.returnError(w, r, http.StatusInternalServerError, "websocket: application specific 'Sec-Websocket-Extensions' headers are unsupported")
+		return u.returnError(w, r, http.StatusInternalServerError, "websocket: application specific 'Sec-WebSocket-Extensions' headers are unsupported")
 	}
 
 	checkOrigin := u.CheckOrigin
@@ -140,7 +140,7 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 
 	challengeKey := r.Header.Get("Sec-Websocket-Key")
 	if challengeKey == "" {
-		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: `Sec-Websocket-Key' header is missing or blank")
+		return u.returnError(w, r, http.StatusBadRequest, "websocket: not a websocket handshake: `Sec-WebSocket-Key' header is missing or blank")
 	}
 
 	subprotocol := u.selectSubprotocol(r, responseHeader)
@@ -190,12 +190,12 @@ func (u *Upgrader) Upgrade(w http.ResponseWriter, r *http.Request, responseHeade
 	p = append(p, computeAcceptKey(challengeKey)...)
 	p = append(p, "\r\n"...)
 	if c.subprotocol != "" {
-		p = append(p, "Sec-Websocket-Protocol: "...)
+		p = append(p, "Sec-WebSocket-Protocol: "...)
 		p = append(p, c.subprotocol...)
 		p = append(p, "\r\n"...)
 	}
 	if compress {
-		p = append(p, "Sec-Websocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n"...)
+		p = append(p, "Sec-WebSocket-Extensions: permessage-deflate; server_no_context_takeover; client_no_context_takeover\r\n"...)
 	}
 	for k, vs := range responseHeader {
 		if k == "Sec-Websocket-Protocol" {

--- a/vendor/github.com/stretchr/objx/Gopkg.lock
+++ b/vendor/github.com/stretchr/objx/Gopkg.lock
@@ -19,8 +19,8 @@
     "assert",
     "require"
   ]
-  revision = "b91bfb9ebec76498946beb6af7c0230c7cc7ba6c"
-  version = "v1.2.0"
+  revision = "12b6f73e6084dad08a7c6e575284b177ecafbc71"
+  version = "v1.2.1"
 
 [solve-meta]
   analyzer-name = "dep"

--- a/vendor/github.com/stretchr/objx/accessors.go
+++ b/vendor/github.com/stretchr/objx/accessors.go
@@ -92,6 +92,12 @@ func access(current interface{}, selector string, value interface{}, isSet bool)
 			curMSI[thisSel] = value
 			return nil
 		}
+
+		_, ok := curMSI[thisSel].(map[string]interface{})
+		if (curMSI[thisSel] == nil || !ok) && index == -1 && isSet {
+			curMSI[thisSel] = map[string]interface{}{}
+		}
+
 		current = curMSI[thisSel]
 	default:
 		current = nil

--- a/vendor/github.com/weaveworks/mesh/README.md
+++ b/vendor/github.com/weaveworks/mesh/README.md
@@ -77,3 +77,13 @@ All contributions should be made as pull requests that satisfy the guidelines, b
 In addition, several mechanical checks are enforced.
 See [the lint script](/lint) for details.
 
+## <a name="help"></a>Getting Help
+
+If you have any questions about, feedback for or problems with `mesh`:
+
+- Invite yourself to the <a href="https://weaveworks.github.io/community-slack/" target="_blank"> #weave-community </a> slack channel.
+- Ask a question on the <a href="https://weave-community.slack.com/messages/general/"> #weave-community</a> slack channel.
+- Send an email to <a href="mailto:weave-users@weave.works">weave-users@weave.works</a>
+- <a href="https://github.com/weaveworks/mesh/issues/new">File an issue.</a>
+
+Your feedback is always welcome!

--- a/vendor/vendor.json
+++ b/vendor/vendor.json
@@ -33,10 +33,10 @@
 			"revisionTime": "2018-01-09T04:46:35Z"
 		},
 		{
-			"checksumSHA1": "uklnMmbUWxbceGp/kvP05EBB3sM=",
+			"checksumSHA1": "jkjbcxHX/oYhxjuvXeyDRbtcnKw=",
 			"path": "github.com/emitter-io/config",
-			"revision": "1f1b29144d9b254306a5b835f831c3ceb3c85e65",
-			"revisionTime": "2018-03-22T08:18:05Z"
+			"revision": "9b25be538a7645678a4a686bc7347a9d86c2d772",
+			"revisionTime": "2018-04-29T05:37:05Z"
 		},
 		{
 			"checksumSHA1": "lcZg+zxtHdtRgQCdjnjvY5CKRg0=",
@@ -51,10 +51,10 @@
 			"revisionTime": "2017-02-15T23:32:05Z"
 		},
 		{
-			"checksumSHA1": "tvVmLXS0w9aMKlZkVyiECxtbZXI=",
+			"checksumSHA1": "YDBzGZ2PAI6cQYpHWI01YlhYo/Y=",
 			"path": "github.com/gorilla/websocket",
-			"revision": "eb925808374e5ca90c83401a40d711dc08c0c0f6",
-			"revisionTime": "2018-03-06T18:15:48Z"
+			"revision": "21ab95fa12b9bdd8fecf5fa3586aad941cc98785",
+			"revisionTime": "2018-04-20T17:16:12Z"
 		},
 		{
 			"checksumSHA1": "pP0b9eRHl4ZFD4zTcWxTZH4CPq0=",
@@ -205,10 +205,10 @@
 			"revisionTime": "2017-07-03T20:58:27Z"
 		},
 		{
-			"checksumSHA1": "+IkucM/8+JlB9p9Ezp55ftFLo6w=",
+			"checksumSHA1": "OGMbdNqR/culumwwltR88pImhqA=",
 			"path": "github.com/stretchr/objx",
-			"revision": "8a3f7159479fbc75b30357fbc48f380b7320f08e",
-			"revisionTime": "2018-01-29T17:20:03Z"
+			"revision": "a5cfa15c000af5f09784e5355969ba7eb66ef0de",
+			"revisionTime": "2018-04-26T10:50:06Z"
 		},
 		{
 			"checksumSHA1": "8DKPX27DIn9aJlrtK2SBdxlynno=",
@@ -247,58 +247,58 @@
 			"revisionTime": "2017-12-07T12:09:41Z"
 		},
 		{
-			"checksumSHA1": "uetYCka74i1t9X24WCO6RD/hQhI=",
+			"checksumSHA1": "2smroOa3YuIO9amCR6MS4F2NanA=",
 			"path": "github.com/weaveworks/mesh",
-			"revision": "0c91e692ee9e89b956b9c4dfc5feb59a0ff87699",
-			"revisionTime": "2018-03-23T17:05:17Z"
+			"revision": "61ba45522f8a5ac096d36674144357341b8ccea9",
+			"revisionTime": "2018-04-16T11:32:25Z"
 		},
 		{
 			"checksumSHA1": "zHLlCNnnX/KNVue2tHr+FWxbszA=",
 			"path": "golang.org/x/crypto/acme",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "6NdRp9OYL38e71vEtcQtSkN/ZbA=",
 			"path": "golang.org/x/crypto/acme/autocert",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "IQkUIOnvlf0tYloFx9mLaXSvXWQ=",
 			"path": "golang.org/x/crypto/curve25519",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "Fy1wkWVRMRkq0/AEzFWwRCib8jU=",
 			"path": "golang.org/x/crypto/nacl/box",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "TwxAhBcGuCzWA6H3FvJE1XVZsxo=",
 			"path": "golang.org/x/crypto/nacl/secretbox",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "1MGpGDQqnUoRpv7VEcQrXOBydXE=",
 			"path": "golang.org/x/crypto/pbkdf2",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "kVKE0OX1Xdw5mG7XKT86DLLKE2I=",
 			"path": "golang.org/x/crypto/poly1305",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "cRCpfAgTnlIDpdcfjivbiv+9YJU=",
 			"path": "golang.org/x/crypto/salsa20/salsa",
-			"revision": "d6449816ce06963d9d136eee5a56fca5b0616e7e",
-			"revisionTime": "2018-04-11T15:42:50Z"
+			"revision": "b49d69b5da943f7ef3c9cf91c8777c1f78a0cc3c",
+			"revisionTime": "2018-04-25T14:55:48Z"
 		},
 		{
 			"checksumSHA1": "AcLbnKmNzH/154S1zpun71QiQIc=",


### PR DESCRIPTION
Autocert TLS-SNI is being faded out and not supported anymore, this PR introduces simple http validation. https://community.letsencrypt.org/t/2018-01-11-update-regarding-acme-tls-sni-and-shared-hosting-infrastructure/50188