### PR TITLE
Removed peer encode out of the lock

### DIFF
--- a/broker/message/message.go
+++ b/broker/message/message.go
@@ -32,6 +32,11 @@ type Message struct {
 	TTL     uint32 `json:"ttl,omitempty"`  // The time-to-live of the message
 }
 
+// NewFrame creates a new frame with the specified capacity
+func NewFrame(capacity int) Frame {
+	return make(Frame, 0, capacity)
+}
+
 // Size returns the byte size of the message.
 func (m *Message) Size() int64 {
 	return int64(len(m.Payload))

--- a/broker/message/message_test.go
+++ b/broker/message/message_test.go
@@ -31,6 +31,12 @@ func TestMessageSize(t *testing.T) {
 	assert.Equal(t, int64(9), m.Size())
 }
 
+func TestNewFrame(t *testing.T) {
+	f := NewFrame(64)
+	assert.Len(t, f, 0)
+	assert.Equal(t, 64, cap(f))
+}
+
 func BenchmarkEncode(b *testing.B) {
 	m := Frame{{
 		Time:    1234,


### PR DESCRIPTION
removing a potential lock contention by swapping to a new object - might do double-buffering instead going forward