### PR TITLE
added from/until query options

### DIFF
--- a/message/id.go
+++ b/message/id.go
@@ -20,6 +20,8 @@ import (
 	"math"
 	"sync/atomic"
 	"time"
+
+	"github.com/emitter-io/emitter/security"
 )
 
 const (
@@ -29,18 +31,13 @@ const (
 var (
 	next   uint32
 	unique = newUnique()
-	offset = time.Date(2018, 1, 1, 0, 0, 0, 0, time.UTC).Unix()
+	offset = int64(security.MinTime) // From 2018 until 2066
 )
 
 func newUnique() uint32 {
 	b := make([]byte, 4)
 	rand.Read(b)
 	return binary.BigEndian.Uint32(b)
-}
-
-// SetDefaultUnique sets the unique number to use when the machine ID is not set.
-func SetDefaultUnique(u uint32) {
-	unique = u
 }
 
 // ID represents a message ID encoded at 128bit and lexigraphically sortable

--- a/security/channel_test.go
+++ b/security/channel_test.go
@@ -114,7 +114,7 @@ func TestParseChannel(t *testing.T) {
 func TestGetChannelTTL(t *testing.T) {
 	tests := []struct {
 		channel string
-		ttl     uint32
+		ttl     int64
 		ok      bool
 	}{
 		{channel: "emitter/a/?ttl=42&abc=9", ttl: 42, ok: true},
@@ -135,7 +135,7 @@ func TestGetChannelTTL(t *testing.T) {
 func TestGetChannelLast(t *testing.T) {
 	tests := []struct {
 		channel string
-		last    uint32
+		last    int64
 		ok      bool
 	}{
 		{channel: "emitter/a/?last=42&abc=9", last: 42, ok: true},
@@ -150,6 +150,33 @@ func TestGetChannelLast(t *testing.T) {
 
 		assert.Equal(t, tc.last, last)
 		assert.Equal(t, hasValue, tc.ok)
+	}
+}
+
+func TestGetChannelWindow(t *testing.T) {
+	tests := []struct {
+		channel string
+		t0      int64
+		t1      int64
+	}{
+		{channel: "emitter/a/?from=42&abc=9", t0: MinTime, t1: MaxTime},
+		{channel: "emitter/a/?from=1200", t0: MinTime, t1: MaxTime},
+		{channel: "emitter/a/?from=1200&until=2550", t0: MinTime, t1: MinTime},
+		{channel: "emitter/a/?from=1200a", t0: MinTime, t1: MaxTime},
+		{channel: "emitter/a/", t0: MinTime, t1: MaxTime},
+		{channel: "emitter/a/?from=1514764800&until=1514764900", t0: 1514764800, t1: 1514764900},
+		{channel: "emitter/a/?from=1514764800", t0: 1514764800, t1: MaxTime},
+		{channel: "emitter/a/?until=1514764900", t0: MinTime, t1: 1514764900},
+		{channel: "emitter/a/?from=1514764800&until=3029529610", t0: 1514764800, t1: MaxTime},
+		{channel: "emitter/a/?from=1514764900&until=1514764800", t0: 1514764900, t1: 1514764900},
+	}
+
+	for _, tc := range tests {
+		channel := ParseChannel([]byte(tc.channel))
+		t0, t1 := channel.Window()
+
+		assert.Equal(t, tc.t0, t0.Unix())
+		assert.Equal(t, tc.t1, t1.Unix())
 	}
 }
 


### PR DESCRIPTION
This PR adds `from` - `until` query options allowing to query message storage using time bounds. Currently this will only work for our `ssd` storage backend.