### PR TITLE
Subprotocol duplicate.

### DIFF
--- a/network/websocket/websocket.go
+++ b/network/websocket/websocket.go
@@ -51,7 +51,7 @@ const (
 
 // The default upgrader to use
 var upgrader = &websocket.Upgrader{
-	Subprotocols: []string{"mqttv3.1", "mqttv3", "mqttv3"},
+	Subprotocols: []string{"mqttv3.1", "mqttv3", "mqtt"},
 	CheckOrigin:  func(r *http.Request) bool { return true },
 }
 


### PR DESCRIPTION
It seems that subprotocol mqttv3 was listed two times by mistake and the last one should be just "mqtt" to be compatible with Paho WebSocket java client.