### PR TITLE
Dockerfile to use Multi-Stage builds (#145)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.9.6-alpine
+FROM golang:alpine AS builder
 MAINTAINER Roman Atachiants "roman@misakai.com"
 
 # Copy the directory into the container.
@@ -7,9 +7,16 @@ WORKDIR /go/src/github.com/emitter-io/emitter/
 ADD . /go/src/github.com/emitter-io/emitter/
 
 # Download and install any required third party dependencies into the container.
-RUN apk add --no-cache g++ \ 
-&& go-wrapper install \
-&& apk del g++
+RUN apk add --no-cache g++ \
+  && go install \
+  && apk del g++
+
+# Base image for runtime
+FROM alpine:latest
+
+WORKDIR /root/
+# Get the executable binary from build-img declared previously
+COPY --from=builder /go/bin/emitter .
 
 # Expose emitter ports
 EXPOSE 4000
@@ -17,4 +24,4 @@ EXPOSE 8080
 EXPOSE 8443
 
 # Start the broker
-CMD ["go-wrapper", "run"]
+CMD ["./emitter"]


### PR DESCRIPTION
This uses latest Golang Alpine Docker image and base image for runtime as Alpine.

Fixes issue #145 