### PR TITLE
Forwarding emitter errors to emitter/error/ channel

### DIFF
--- a/broker/conn_test.go
+++ b/broker/conn_test.go
@@ -1,1 +1,53 @@
+/**********************************************************************************
+* Copyright (c) 2009-2017 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
 package broker
+
+import (
+	"io/ioutil"
+	"testing"
+
+	"github.com/emitter-io/emitter/message"
+	netmock "github.com/emitter-io/emitter/network/mock"
+	"github.com/emitter-io/emitter/security"
+	"github.com/emitter-io/stats"
+	"github.com/stretchr/testify/assert"
+)
+
+func newTestConn() (pipe *netmock.Conn, conn *Conn) {
+	license, _ := security.ParseLicense(testLicense)
+	s := &Service{
+		subscriptions: message.NewTrie(),
+		License:       license,
+		measurer:      stats.NewNoop(),
+	}
+
+	pipe = netmock.NewConn()
+	conn = s.newConn(pipe.Client)
+	return
+}
+
+func TestNotifyError(t *testing.T) {
+	pipe, conn := newTestConn()
+	assert.NotNil(t, pipe)
+
+	go func() {
+		conn.notifyError(ErrUnauthorized)
+		conn.Close()
+	}()
+
+	b, err := ioutil.ReadAll(pipe.Server)
+	assert.Contains(t, string(b), ErrUnauthorized.Message)
+	assert.NoError(t, err)
+}

--- a/broker/handlers.go
+++ b/broker/handlers.go
@@ -34,7 +34,7 @@ const (
 // ------------------------------------------------------------------------------------
 
 // OnSubscribe is a handler for MQTT Subscribe events.
-func (c *Conn) onSubscribe(mqttTopic []byte) *EventError {
+func (c *Conn) onSubscribe(mqttTopic []byte) *Error {
 
 	// Parse the channel
 	channel := security.ParseChannel(mqttTopic)
@@ -97,7 +97,7 @@ func (c *Conn) onSubscribe(mqttTopic []byte) *EventError {
 // ------------------------------------------------------------------------------------
 
 // OnUnsubscribe is a handler for MQTT Unsubscribe events.
-func (c *Conn) onUnsubscribe(mqttTopic []byte) *EventError {
+func (c *Conn) onUnsubscribe(mqttTopic []byte) *Error {
 
 	// Parse the channel
 	channel := security.ParseChannel(mqttTopic)
@@ -142,7 +142,7 @@ func (c *Conn) onUnsubscribe(mqttTopic []byte) *EventError {
 // ------------------------------------------------------------------------------------
 
 // OnPublish is a handler for MQTT Publish events.
-func (c *Conn) onPublish(mqttTopic []byte, payload []byte) *EventError {
+func (c *Conn) onPublish(mqttTopic []byte, payload []byte) *Error {
 
 	// Parse the channel
 	channel := security.ParseChannel(mqttTopic)

--- a/broker/handlers_dto.go
+++ b/broker/handlers_dto.go
@@ -1,3 +1,17 @@
+/**********************************************************************************
+* Copyright (c) 2009-2017 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
 package broker
 
 import (
@@ -9,26 +23,26 @@ import (
 	"github.com/emitter-io/emitter/security"
 )
 
-// EventError represents an event code which provides a more de.
-type EventError struct {
+// Error represents an event code which provides a more details.
+type Error struct {
 	Status  int    `json:"status"`
 	Message string `json:"message"`
 }
 
 // Error implements error interface.
-func (e *EventError) Error() string { return e.Message }
+func (e *Error) Error() string { return e.Message }
 
 // Represents a set of errors used in the handlers.
 var (
-	ErrBadRequest      = &EventError{Status: 400, Message: "The request was invalid or cannot be otherwise served."}
-	ErrUnauthorized    = &EventError{Status: 401, Message: "The security key provided is not authorized to perform this operation."}
-	ErrPaymentRequired = &EventError{Status: 402, Message: "The request can not be served, as the payment is required to proceed."}
-	ErrForbidden       = &EventError{Status: 403, Message: "The request is understood, but it has been refused or access is not allowed."}
-	ErrNotFound        = &EventError{Status: 404, Message: "The resource requested does not exist."}
-	ErrServerError     = &EventError{Status: 500, Message: "An unexpected condition was encountered and no more specific message is suitable."}
-	ErrNotImplemented  = &EventError{Status: 501, Message: "The server either does not recognize the request method, or it lacks the ability to fulfill the request."}
-	ErrTargetInvalid   = &EventError{Status: 400, Message: "Channel should end with `/` for strict types or `/#/` for wildcards."}
-	ErrTargetTooLong   = &EventError{Status: 400, Message: "Channel can not have more than 23 parts."}
+	ErrBadRequest      = &Error{Status: 400, Message: "The request was invalid or cannot be otherwise served."}
+	ErrUnauthorized    = &Error{Status: 401, Message: "The security key provided is not authorized to perform this operation."}
+	ErrPaymentRequired = &Error{Status: 402, Message: "The request can not be served, as the payment is required to proceed."}
+	ErrForbidden       = &Error{Status: 403, Message: "The request is understood, but it has been refused or access is not allowed."}
+	ErrNotFound        = &Error{Status: 404, Message: "The resource requested does not exist."}
+	ErrServerError     = &Error{Status: 500, Message: "An unexpected condition was encountered and no more specific message is suitable."}
+	ErrNotImplemented  = &Error{Status: 501, Message: "The server either does not recognize the request method, or it lacks the ability to fulfill the request."}
+	ErrTargetInvalid   = &Error{Status: 400, Message: "Channel should end with `/` for strict types or `/#/` for wildcards."}
+	ErrTargetTooLong   = &Error{Status: 400, Message: "Channel can not have more than 23 parts."}
 )
 
 // ------------------------------------------------------------------------------------

--- a/broker/handlers_test.go
+++ b/broker/handlers_test.go
@@ -47,9 +47,9 @@ func TestHandlers_onSubscribeUnsubscribe(t *testing.T) {
 		{
 			channel:       "0Nq8SWbL8qoOKEDqh_ebBepug6cLLlWO/a/b/c/",
 			subCount:      1,
-			subErr:        (*EventError)(nil),
+			subErr:        (*Error)(nil),
 			unsubCount:    0,
-			unsubErr:      (*EventError)(nil),
+			unsubErr:      (*Error)(nil),
 			contractValid: true,
 			contractFound: true,
 			msg:           "Successful case",
@@ -178,7 +178,7 @@ func TestHandlers_onPublish(t *testing.T) {
 		{
 			channel:       "0Nq8SWbL8qoOKEDqh_ebBepug6cLLlWO/a/b/c/",
 			payload:       "test",
-			err:           (*EventError)(nil),
+			err:           (*Error)(nil),
 			contractValid: true,
 			contractFound: true,
 			msg:           "Successful case",
@@ -242,7 +242,7 @@ func TestHandlers_onPublish(t *testing.T) {
 		{
 			channel:       "0Nq8SWbL8qoOKEDqh_ebBepug6cLLlWO/a/b/c/",
 			payload:       "test",
-			err:           (*EventError)(nil),
+			err:           (*Error)(nil),
 			contractValid: true,
 			contractFound: true,
 			msg:           "No store permission case",
@@ -455,7 +455,7 @@ func TestHandlers_onKeygen(t *testing.T) {
 			assert.Equal(t, tc.generated, generated, tc.msg)
 
 			if !generated {
-				keyGenResp := resp.(*EventError)
+				keyGenResp := resp.(*Error)
 				assert.Equal(t, tc.resp, keyGenResp)
 			} else {
 				keyGenResp := resp.(*keyGenResponse)


### PR DESCRIPTION
This PR enables forwarding of broker error messages to `emitter/error/` channel. This can hopefully alleviate some of the pain when dealing with channel keys and developing client apps.

https://github.com/emitter-io/emitter/issues/113 