### PR TITLE
Multiple subscription fixes

### DIFF
--- a/internal/broker/cluster/memberlist.go
+++ b/internal/broker/cluster/memberlist.go
@@ -1,0 +1,72 @@
+/**********************************************************************************
+* Copyright (c) 2009-2017 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package cluster
+
+import (
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/weaveworks/mesh"
+)
+
+// memberlist represents a peer cache
+type memberlist struct {
+	list sync.Map
+	ctor func(mesh.PeerName) *Peer
+}
+
+// newMemberlist creates a new memberlist
+func newMemberlist(ctor func(mesh.PeerName) *Peer) *memberlist {
+	return &memberlist{
+		ctor: ctor,
+	}
+}
+
+// GetOrAdd gets or adds a peer, returns a peer and whether a new peer was added or not
+func (m *memberlist) GetOrAdd(name mesh.PeerName) (*Peer, bool) {
+	if p, ok := m.list.Load(name); ok {
+		return p.(*Peer), false
+	}
+
+	// Create new peer and store it
+	peer := m.ctor(name)
+	v, loaded := m.list.LoadOrStore(name, peer)
+	return v.(*Peer), !loaded
+}
+
+// Touch updates the last activity time
+func (m *memberlist) Touch(name mesh.PeerName) {
+	peer, _ := m.GetOrAdd(name)
+	atomic.StoreInt64(&peer.activity, time.Now().Unix())
+}
+
+// Contains checks if a peer is in the memberlist
+func (m *memberlist) Contains(name mesh.PeerName) bool {
+	_, ok := m.list.Load(name)
+	return ok
+}
+
+// Remove removes the peer from the memberlist
+func (m *memberlist) Remove(name mesh.PeerName) (*Peer, bool) {
+	if p, ok := m.list.Load(name); ok {
+		peer := p.(*Peer)
+		m.list.Delete(peer.name)
+		atomic.StoreInt64(&peer.activity, 0)
+		return peer, true
+	}
+
+	return nil, false
+}

--- a/internal/broker/cluster/memberlist_test.go
+++ b/internal/broker/cluster/memberlist_test.go
@@ -1,0 +1,15 @@
+/**********************************************************************************
+* Copyright (c) 2009-2017 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package cluster

--- a/internal/broker/cluster/peer.go
+++ b/internal/broker/cluster/peer.go
@@ -118,11 +118,6 @@ func (p *Peer) swap() (swapped message.Frame) {
 	return
 }
 
-// Touch updates the activity time of the peer.
-func (p *Peer) touch() {
-	atomic.StoreInt64(&p.activity, time.Now().Unix())
-}
-
 // processSendQueue flushes the current frame to the remote server
 func (p *Peer) processSendQueue() {
 	if len(p.frame) == 0 {

--- a/internal/broker/cluster/swarm_test.go
+++ b/internal/broker/cluster/swarm_test.go
@@ -72,14 +72,12 @@ func TestNewSwarm_Scenario(t *testing.T) {
 	assert.Equal(t, io.EOF, err)
 
 	// Find peer
-	peer, hasPeer := s.FindPeer(123)
-	assert.False(t, hasPeer)
-	assert.Nil(t, peer)
+	peer := s.FindPeer(123)
+	assert.NotNil(t, peer)
 
 	// Remove that peer, it should not be there
 	s.onPeerOffline(123)
-	_, ok := s.members.Load(mesh.PeerName(123))
-	assert.False(t, ok)
+	assert.False(t, s.members.Contains(mesh.PeerName(123)))
 
 	// Close the swarm
 	err = s.Close()
@@ -131,9 +129,10 @@ func Test_merge(t *testing.T) {
 	}
 	defer s.Close()
 
+	s.members.Touch(2)
 	_, err := s.merge(in.Encode()[0])
 	assert.NoError(t, err)
-	assert.False(t, subscribed)
+	assert.True(t, subscribed)
 }
 
 func TestJoin(t *testing.T) {

--- a/internal/broker/query.go
+++ b/internal/broker/query.go
@@ -126,9 +126,9 @@ func (c *QueryManager) onRequest(ssid message.Ssid, channel string, payload []by
 	}
 
 	// Get the peer to reply to
-	peer, ok := c.service.cluster.FindPeer(replyAddr)
-	if !ok {
-		return errors.New("unable to reply to a request, peer does not exist")
+	peer := c.service.cluster.FindPeer(replyAddr)
+	if !peer.IsActive() {
+		return errors.New("unable to reply to a request, peer is not active")
 	}
 
 	// Go through all the handlers and execute the first matching one


### PR DESCRIPTION
This PR fixes few issues with the subscription state. 
 - When a server is removed and added again to the cluster, it no longer resubscribes to itself. 
 - When a peer is detected as offline, its subscriptions are no longer lingering in the LLWSet.
 - When a broker joins the cluster indirectly, it no longer misses some of the subscriptions.