### PR TITLE
Feature: Added a 'me=0' option to skip self-published events

### DIFF
--- a/internal/broker/conn.go
+++ b/internal/broker/conn.go
@@ -123,7 +123,7 @@ func (c *Conn) Process() error {
 
 // notifyError notifies the connection about an error
 func (c *Conn) notifyError(err *Error, messageID uint16) {
-	err.ID = int(messageID)
+	// TODO: pass '?req=messageID' back
 	if b, err := json.Marshal(err); err == nil {
 		c.Send(&message.Message{
 			Channel: []byte("emitter/error/"),

--- a/internal/broker/handlers.go
+++ b/internal/broker/handlers.go
@@ -182,6 +182,11 @@ func (c *Conn) onPublish(mqttTopic []byte, payload []byte) *Error {
 		c.service.storage.Store(msg)
 	}
 
+	// Check whether an exclude me option was set (i.e.: 'me=0')
+	if channel.Exclude() {
+		exclude = c.ID()
+	}
+
 	// Iterate through all subscribers and send them the message
 	size := c.service.publish(msg, exclude)
 
@@ -200,7 +205,7 @@ func (c *Conn) onEmitterRequest(channel *security.Channel, payload []byte) (ok b
 	defer func() {
 		if b, err := json.Marshal(resp); err == nil {
 			c.Send(&message.Message{
-				Channel: []byte("emitter/" + string(channel.Channel)), // TODO: reduce allocations
+				Channel: []byte(channel.String()), // if the 'req' option was passed, it will be in the channel
 				Payload: b,
 			})
 		}

--- a/internal/broker/handlers_dto.go
+++ b/internal/broker/handlers_dto.go
@@ -27,7 +27,6 @@ import (
 type Error struct {
 	Status  int    `json:"status"`
 	Message string `json:"message"`
-	ID      int    `json:"id,omitempty"`
 }
 
 // Error implements error interface.
@@ -50,10 +49,10 @@ var (
 // ------------------------------------------------------------------------------------
 
 type keyGenRequest struct {
-	Key     string `json:"key"`
-	Channel string `json:"channel"`
-	Type    string `json:"type"`
-	TTL     int32  `json:"ttl"`
+	Key     string `json:"key"`     // The master key to use.
+	Channel string `json:"channel"` // The channel to create a key for.
+	Type    string `json:"type"`    // The permission set.
+	TTL     int32  `json:"ttl"`     // The TTL of the key.
 }
 
 func (m *keyGenRequest) expires() time.Time {

--- a/internal/broker/service_test.go
+++ b/internal/broker/service_test.go
@@ -216,6 +216,16 @@ func TestPubsub(t *testing.T) {
 		}, pkt)
 	}
 
+	{ // Publish a message but ignore ourselves
+		msg := mqtt.Publish{
+			Header:  &mqtt.StaticHeader{QOS: 0},
+			Topic:   []byte("0Nq8SWbL8qoOKEDqh_ebBepug6cLLlWO/a/b/c/?me=0"),
+			Payload: []byte("hello world"),
+		}
+		_, err := msg.EncodeTo(cli)
+		assert.NoError(t, err)
+	}
+
 	{ // Unsubscribe from the topic
 		sub := mqtt.Unsubscribe{
 			Header: &mqtt.StaticHeader{QOS: 0},
@@ -236,7 +246,7 @@ func TestPubsub(t *testing.T) {
 	{ // Create a private link
 		msg := mqtt.Publish{
 			Header:  &mqtt.StaticHeader{QOS: 0},
-			Topic:   []byte("emitter/link/"),
+			Topic:   []byte("emitter/link/?req=1"),
 			Payload: []byte(`{ "name": "hi", "key": "k44Ss59ZSxg6Zyz39kLwN-2t5AETnGpm", "channel": "a/b/c/", "private": true }`),
 		}
 		_, err := msg.EncodeTo(cli)

--- a/internal/security/channel_test.go
+++ b/internal/security/channel_test.go
@@ -45,6 +45,7 @@ func TestParseChannel(t *testing.T) {
 		{k: "emitter", ch: "b/+/", t: ChannelWildcard},
 		{k: "0TJnt4yZPL73zt35h1UTIFsYBLetyD_g", ch: "emitter/", o: []string{"test=true", "something=7"}, t: ChannelStatic},
 		{k: "emitter", ch: "a/b/c/d/", o: []string{"test=true", "something=7"}, t: ChannelStatic},
+		{k: "emitter", ch: "a/b/c/d/", o: []string{"req=13", "something=7"}, t: ChannelStatic},
 
 		// Invalid channels
 		{t: ChannelInvalid},
@@ -108,6 +109,47 @@ func TestParseChannel(t *testing.T) {
 				assert.Equal(t, true, found, "unable to find key = "+target)
 			}
 		}
+	}
+}
+
+func TestGetChannelExclude(t *testing.T) {
+	tests := []struct {
+		channel string
+		ok      bool
+	}{
+		{channel: "emitter/a/?me=0", ok: true},
+		{channel: "emitter/a/?me=12000000", ok: false},
+		{channel: "emitter/a/?me=1200a", ok: false},
+		{channel: "emitter/a/?me=-1", ok: false},
+		{channel: "emitter/a/", ok: false},
+	}
+
+	for _, tc := range tests {
+		channel := ParseChannel([]byte(tc.channel))
+		excludeMe := channel.Exclude()
+
+		assert.Equal(t, excludeMe, tc.ok)
+	}
+}
+
+func TestGetChannelRequest(t *testing.T) {
+	tests := []struct {
+		channel string
+		req     uint16
+		ok      bool
+	}{
+		{channel: "emitter/a/?req=42", req: 42, ok: true},
+		{channel: "emitter/a/?req=12000000", ok: false},
+		{channel: "emitter/a/?req=1200a", ok: false},
+		{channel: "emitter/a/", ok: false},
+	}
+
+	for _, tc := range tests {
+		channel := ParseChannel([]byte(tc.channel))
+		req, hasValue := channel.Request()
+
+		assert.Equal(t, tc.req, req)
+		assert.Equal(t, hasValue, tc.ok)
 	}
 }
 


### PR DESCRIPTION
This PR introduces a way of skipping self-published messages. This is useful if a client is using same topic to send and receive messages, and has both publish and subscribe capabilities.