### PR TITLE
Added request ID for emitter responses

### DIFF
--- a/internal/broker/handlers_dto.go
+++ b/internal/broker/handlers_dto.go
@@ -23,14 +23,27 @@ import (
 	"github.com/emitter-io/emitter/internal/security"
 )
 
+// Response represents a response which can be sent for a specific request.
+type response interface {
+	ForRequest(uint16)
+}
+
+// ------------------------------------------------------------------------------------
+
 // Error represents an event code which provides a more details.
 type Error struct {
+	Request uint16 `json:"req,omitempty"`
 	Status  int    `json:"status"`
 	Message string `json:"message"`
 }
 
 // Error implements error interface.
 func (e *Error) Error() string { return e.Message }
+
+// ForRequest sets the request ID in the response for matching
+func (e *Error) ForRequest(id uint16) {
+	e.Request = id
+}
 
 // Represents a set of errors used in the handlers.
 var (
@@ -42,7 +55,7 @@ var (
 	ErrServerError     = &Error{Status: 500, Message: "an unexpected condition was encountered and no more specific message is suitable"}
 	ErrNotImplemented  = &Error{Status: 501, Message: "the server either does not recognize the request method, or it lacks the ability to fulfill the request"}
 	ErrTargetInvalid   = &Error{Status: 400, Message: "channel should end with `/` for strict types or `/#/` for wildcards"}
-	ErrTargetTooLong   = &Error{Status: 400, Message: "channel can not have more than 23 parts."}
+	ErrTargetTooLong   = &Error{Status: 400, Message: "channel can not have more than 23 parts"}
 	ErrLinkInvalid     = &Error{Status: 400, Message: "the link must be an alphanumeric string of 1 or 2 characters"}
 )
 
@@ -91,9 +104,15 @@ func (m *keyGenRequest) access() uint8 {
 // ------------------------------------------------------------------------------------
 
 type keyGenResponse struct {
+	Request uint16 `json:"req,omitempty"`
 	Status  int    `json:"status"`
 	Key     string `json:"key"`
 	Channel string `json:"channel"`
+}
+
+// ForRequest sets the request ID in the response for matching
+func (r *keyGenResponse) ForRequest(id uint16) {
+	r.Request = id
 }
 
 // ------------------------------------------------------------------------------------
@@ -109,16 +128,28 @@ type linkRequest struct {
 // ------------------------------------------------------------------------------------
 
 type linkResponse struct {
+	Request uint16 `json:"req,omitempty"`     // The corresponding request ID.
 	Status  int    `json:"status"`            // The status of the response.
 	Name    string `json:"name,omitempty"`    // The name of the shortcut, max 2 characters.
 	Channel string `json:"channel,omitempty"` // The channel which was registered.
 }
 
+// ForRequest sets the request ID in the response for matching
+func (r *linkResponse) ForRequest(id uint16) {
+	r.Request = id
+}
+
 // ------------------------------------------------------------------------------------
 
 type meResponse struct {
-	ID    string            `json:"id"`              // The private ID of the connection.
-	Links map[string]string `json:"links,omitempty"` // The set of pre-defined channels.
+	Request uint16            `json:"req,omitempty"`   // The corresponding request ID.
+	ID      string            `json:"id"`              // The private ID of the connection.
+	Links   map[string]string `json:"links,omitempty"` // The set of pre-defined channels.
+}
+
+// ForRequest sets the request ID in the response for matching
+func (r *meResponse) ForRequest(id uint16) {
+	r.Request = id
 }
 
 // ------------------------------------------------------------------------------------
@@ -142,10 +173,16 @@ const (
 
 // presenceNotify represents a state notification.
 type presenceResponse struct {
-	Time    int64          `json:"time"`    // The UNIX timestamp.
-	Event   presenceEvent  `json:"event"`   // The event, must be "status", "subscribe" or "unsubscribe".
-	Channel string         `json:"channel"` // The target channel for the notification.
-	Who     []presenceInfo `json:"who"`     // The subscriber ids.
+	Request uint16         `json:"req,omitempty"` // The corresponding request ID.
+	Time    int64          `json:"time"`          // The UNIX timestamp.
+	Event   presenceEvent  `json:"event"`         // The event, must be "status", "subscribe" or "unsubscribe".
+	Channel string         `json:"channel"`       // The target channel for the notification.
+	Who     []presenceInfo `json:"who"`           // The subscriber ids.
+}
+
+// ForRequest sets the request ID in the response for matching
+func (r *presenceResponse) ForRequest(id uint16) {
+	r.Request = id
 }
 
 // ------------------------------------------------------------------------------------

--- a/internal/broker/handlers_test.go
+++ b/internal/broker/handlers_test.go
@@ -320,7 +320,7 @@ func TestHandlers_onPublish(t *testing.T) {
 		nc := s.newConn(conn.Client)
 		s.Cipher, _ = s.License.Cipher()
 
-		err := nc.onPublish([]byte(tc.channel), []byte(tc.payload))
+		err := nc.onPublish([]byte(tc.channel), []byte(tc.payload), 0)
 
 		assert.Equal(t, tc.err, err, tc.msg)
 	}
@@ -572,7 +572,7 @@ func TestHandlers_onEmitterRequest(t *testing.T) {
 			}
 
 			nc := s.newConn(netmock.NewNoop())
-			ok := nc.onEmitterRequest(channel, []byte(tc.payload))
+			ok := nc.onEmitterRequest(channel, []byte(tc.payload), 0)
 			assert.Equal(t, tc.success, ok, tc.channel)
 		})
 	}

--- a/internal/security/channel.go
+++ b/internal/security/channel.go
@@ -69,12 +69,6 @@ func (c *Channel) Last() (int64, bool) {
 	return c.getOption("last", 64)
 }
 
-// Request returns an optional request ID for response mapping.
-func (c *Channel) Request() (uint16, bool) {
-	v, ok := c.getOption("req", 16)
-	return uint16(v), ok
-}
-
 // Exclude returns whether the exclude me ('me=0') option was set or not.
 func (c *Channel) Exclude() bool {
 	v, ok := c.getOption("me", 64)

--- a/internal/security/channel_test.go
+++ b/internal/security/channel_test.go
@@ -132,27 +132,6 @@ func TestGetChannelExclude(t *testing.T) {
 	}
 }
 
-func TestGetChannelRequest(t *testing.T) {
-	tests := []struct {
-		channel string
-		req     uint16
-		ok      bool
-	}{
-		{channel: "emitter/a/?req=42", req: 42, ok: true},
-		{channel: "emitter/a/?req=12000000", ok: false},
-		{channel: "emitter/a/?req=1200a", ok: false},
-		{channel: "emitter/a/", ok: false},
-	}
-
-	for _, tc := range tests {
-		channel := ParseChannel([]byte(tc.channel))
-		req, hasValue := channel.Request()
-
-		assert.Equal(t, tc.req, req)
-		assert.Equal(t, hasValue, tc.ok)
-	}
-}
-
 func TestGetChannelTTL(t *testing.T) {
 	tests := []struct {
 		channel string


### PR DESCRIPTION
This PR adds request IDs for each 'emitter/.../' response. These requests IDs only work with QoS=1 as they're actually MQTT message IDs.