### PR TITLE
Make Maximum Message Size as configurable.

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ The structure of the configuration is described below:
 |---|---|---|
 | `license` | `EMITTER_LICENSE` | The license file to use for the broker. This contains the encryption key. |
 | `listen` | `EMITTER_LISTEN` | The API address used for TCP & Websocket communication, in `IP:PORT` format (e.g: `:8080`). |
-| `maxMessageSize` | `EMITTER_MAXMESSAGESIZE` | Maximum message size. Default is 64KB.
+| `limit.messageSize` | `EMITTER_LIMIT_MESSAGESIZE` | Maximum message size. Default is 64KB.
 | `tls.listen` | `EMITTER_TLS_LISTEN` |The API address used for Secure TCP & Websocket communication, in `IP:PORT` format (e.g: `:443`).  |
 | `tls.host` | `EMITTER_TLS_HOST` | The hostname to whitelist for the certificate.  |
 | `tls.email` | `EMITTER_TLS_EMAIL` |The email account to use for autocert. |

--- a/README.md
+++ b/README.md
@@ -134,6 +134,7 @@ The structure of the configuration is described below:
 |---|---|---|
 | `license` | `EMITTER_LICENSE` | The license file to use for the broker. This contains the encryption key. |
 | `listen` | `EMITTER_LISTEN` | The API address used for TCP & Websocket communication, in `IP:PORT` format (e.g: `:8080`). |
+| `maxMessageSize` | `EMITTER_MAXMESSAGESIZE` | Maximum message size. Default is 64KB.
 | `tls.listen` | `EMITTER_TLS_LISTEN` |The API address used for Secure TCP & Websocket communication, in `IP:PORT` format (e.g: `:443`).  |
 | `tls.host` | `EMITTER_TLS_HOST` | The hostname to whitelist for the certificate.  |
 | `tls.email` | `EMITTER_TLS_EMAIL` |The email account to use for autocert. |

--- a/internal/broker/conn.go
+++ b/internal/broker/conn.go
@@ -103,13 +103,13 @@ func (c *Conn) track(contract contract.Contract) {
 func (c *Conn) Process() error {
 	defer c.Close()
 	reader := bufio.NewReaderSize(c.socket, 65536)
-
+	maxMessageSize := c.service.Config.MaxMessageBytes()
 	for {
 		// Set read/write deadlines so we can close dangling connections
 		c.socket.SetDeadline(time.Now().Add(time.Second * 120))
 
 		// Decode an incoming MQTT packet
-		msg, err := mqtt.DecodePacket(reader)
+		msg, err := mqtt.DecodePacket(reader, maxMessageSize)
 		if err != nil {
 			return err
 		}

--- a/internal/broker/service_test.go
+++ b/internal/broker/service_test.go
@@ -163,7 +163,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read connack
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfConnack, pkt.Type())
 	}
@@ -176,7 +176,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read pong
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli,65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPingresp, pkt.Type())
 	}
@@ -203,7 +203,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read the retained message
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli,65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPublish, pkt.Type())
 		assert.Equal(t, &mqtt.Publish{
@@ -214,7 +214,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read suback
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli,65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfSuback, pkt.Type())
 	}
@@ -230,7 +230,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read the message back
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli,65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPublish, pkt.Type())
 		assert.Equal(t, &mqtt.Publish{
@@ -262,7 +262,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read unsuback
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli,65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfUnsuback, pkt.Type())
 	}
@@ -278,7 +278,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read the link response
-		pkt, err := mqtt.DecodePacket(cli)
+		pkt, err := mqtt.DecodePacket(cli,65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPublish, pkt.Type())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,8 +27,9 @@ import (
 
 // Constants used throughout the service.
 const (
-	ChannelSeparator = '/'   // The separator character.
-	MaxMessageSize   = 65536 // Maximum message size allowed from/to the peer.
+	ChannelSeparator         = '/'   // The separator character.
+	maxMessageSize           = 65536 // Default Maximum message size allowed from/to the peer.
+	EncodingBufferSize       = 65536 // Initial buffer size for encoding buffers
 )
 
 // VaultUser is the vault user to use for authentication
@@ -82,20 +83,30 @@ func New(filename string, stores ...cfg.SecretStore) *Config {
 
 // Config represents main configuration.
 type Config struct {
-	ListenAddr string              `json:"listen"`             // The API port used for TCP & Websocket communication.
-	License    string              `json:"license"`            // The license file to use for the broker.
-	TLS        *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
-	Cluster    *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.
-	Storage    *cfg.ProviderConfig `json:"storage,omitempty"`  // The configuration for the storage provider.
-	Contract   *cfg.ProviderConfig `json:"contract,omitempty"` // The configuration for the contract provider.
-	Metering   *cfg.ProviderConfig `json:"metering,omitempty"` // The configuration for the usage storage for metering.
-	Logging    *cfg.ProviderConfig `json:"logging,omitempty"`  // The configuration for the logger.
-	Monitor    *cfg.ProviderConfig `json:"monitor,omitempty"`  // The configuration for the monitoring storage.
-	Vault      secretStoreConfig   `json:"vault,omitempty"`    // The configuration for the Hashicorp Vault Secret Store.
-	Dynamo     secretStoreConfig   `json:"dynamodb,omitempty"` // The configuration for the AWS DynamoDB Secret Store.
+	ListenAddr     string              `json:"listen"`             // The API port used for TCP & Websocket communication.
+	License        string              `json:"license"`            // The license file to use for the broker.
+	MaxMessageSize int               `json:"maxMessageSize"`     // Maximum message size allowed from/to the peer
+	TLS            *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
+	Cluster        *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.
+	Storage        *cfg.ProviderConfig `json:"storage,omitempty"`  // The configuration for the storage provider.
+	Contract       *cfg.ProviderConfig `json:"contract,omitempty"` // The configuration for the contract provider.
+	Metering       *cfg.ProviderConfig `json:"metering,omitempty"` // The configuration for the usage storage for metering.
+	Logging        *cfg.ProviderConfig `json:"logging,omitempty"`  // The configuration for the logger.
+	Monitor        *cfg.ProviderConfig `json:"monitor,omitempty"`  // The configuration for the monitoring storage.
+	Vault          secretStoreConfig   `json:"vault,omitempty"`    // The configuration for the Hashicorp Vault Secret Store.
+	Dynamo         secretStoreConfig   `json:"dynamodb,omitempty"` // The configuration for the AWS DynamoDB Secret Store.
 
 	listenAddr *net.TCPAddr     // The listen address, parsed.
 	certCaches []cfg.CertCacher // The certificate caches configured.
+}
+
+
+func (c *Config) MaxMessageBytes() int64{
+	//return default if not configured
+	if c.MaxMessageSize <= 0{
+		return maxMessageSize
+	}
+	return int64(c.MaxMessageSize)
 }
 
 // Addr returns the listen address configured.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,7 @@ func New(filename string, stores ...cfg.SecretStore) *Config {
 type Config struct {
 	ListenAddr     string              `json:"listen"`             // The API port used for TCP & Websocket communication.
 	License        string              `json:"license"`            // The license file to use for the broker.
-	MaxMessageSize int               `json:"maxMessageSize"`     // Maximum message size allowed from/to the peer
+	Limit		   *LimitConfig        `json:"limit,omitempty"`    // Configuration for various limits.
 	TLS            *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
 	Cluster        *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.
 	Storage        *cfg.ProviderConfig `json:"storage,omitempty"`  // The configuration for the storage provider.
@@ -103,10 +103,10 @@ type Config struct {
 
 func (c *Config) MaxMessageBytes() int64{
 	//return default if not configured
-	if c.MaxMessageSize <= 0{
+	if c.Limit == nil || c.Limit.MessageSize <= 0{
 		return maxMessageSize
 	}
-	return int64(c.MaxMessageSize)
+	return int64(c.Limit.MessageSize)
 }
 
 // Addr returns the listen address configured.
@@ -157,6 +157,11 @@ type ClusterConfig struct {
 	// Passphrase is used to initialize the primary encryption key in a keyring. This key
 	// is used for encrypting all the gossip messages (message-level encryption).
 	Passphrase string `json:"passphrase,omitempty"`
+}
+
+//Limit represent various limit configurations - such as message size.
+type LimitConfig struct{
+	MessageSize int `json:"messageSize,omitempty"` //Maximum message size allowed from/to the peer
 }
 
 // LoadProvider loads a provider from the configuration or panics if the configuration is

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -85,7 +85,7 @@ func New(filename string, stores ...cfg.SecretStore) *Config {
 type Config struct {
 	ListenAddr     string              `json:"listen"`             // The API port used for TCP & Websocket communication.
 	License        string              `json:"license"`            // The license file to use for the broker.
-	Limit		   *LimitConfig        `json:"limit,omitempty"`    // Configuration for various limits.
+	Limit		   *LimitConfig        `json:"limit,omitempty"`    // Configuration for various limits such as message size.
 	TLS            *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
 	Cluster        *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.
 	Storage        *cfg.ProviderConfig `json:"storage,omitempty"`  // The configuration for the storage provider.
@@ -161,7 +161,8 @@ type ClusterConfig struct {
 
 //Limit represent various limit configurations - such as message size.
 type LimitConfig struct{
-	MessageSize int `json:"messageSize,omitempty"` //Maximum message size allowed from/to the peer
+	//Maximum message size allowed from/to the peer. Default if not specified is 64kB.
+	MessageSize int `json:"messageSize,omitempty"`
 }
 
 // LoadProvider loads a provider from the configuration or panics if the configuration is

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -41,3 +41,10 @@ func Test_New(t *testing.T) {
 
 	assert.NotNil(t, c)
 }
+
+func Test_DefaultMaxMessageSize(t *testing.T){
+	c := New("test.conf", dynamo.NewProvider())
+	defer os.Remove("test.conf")
+
+	assert.EqualValues(t, c.MaxMessageBytes(), maxMessageSize)
+}

--- a/internal/network/mqtt/mqtt.go
+++ b/internal/network/mqtt/mqtt.go
@@ -24,7 +24,7 @@ import (
 )
 
 // buffers are reusable fixed-side buffers for faster encoding.
-var buffers = collection.NewBufferPool(config.MaxMessageSize)
+var buffers = collection.NewBufferPool(config.EncodingBufferSize)
 
 // reserveForHeader reserves the bytes for a header.
 var reserveForHeader = []byte{0x0, 0x0, 0x0, 0x0, 0x0, 0x0}
@@ -169,7 +169,7 @@ type TopicQOSTuple struct {
 }
 
 // DecodePacket decodes the packet from the provided reader.
-func DecodePacket(rdr io.Reader) (Message, error) {
+func DecodePacket(rdr io.Reader, maxMessageSize int64) (Message, error) {
 	hdr, sizeOf, messageType, err := decodeStaticHeader(rdr)
 	if err != nil {
 		return nil, err
@@ -186,7 +186,7 @@ func DecodePacket(rdr io.Reader) (Message, error) {
 	}
 
 	//check to make sure packet isn't above size limit
-	if int64(sizeOf) > config.MaxMessageSize {
+	if int64(sizeOf) > maxMessageSize {
 		return nil, fmt.Errorf("Message size is too large")
 	}
 

--- a/internal/network/mqtt/mqtt_test.go
+++ b/internal/network/mqtt/mqtt_test.go
@@ -8,7 +8,6 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/emitter-io/emitter/internal/config"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -81,7 +80,7 @@ func benchmarkPacketDecode(b *testing.B, packet Message) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		reader.Seek(0, io.SeekStart)
-		_, err := DecodePacket(reader)
+		_, err := DecodePacket(reader,65536)
 		if err != nil {
 			b.Error(err)
 		}
@@ -89,7 +88,7 @@ func benchmarkPacketDecode(b *testing.B, packet Message) {
 }
 
 func Test_LargePacket(t *testing.T) {
-	pay := make([]byte, config.MaxMessageSize-10)
+	pay := make([]byte, 65536-10)
 	for i := range pay {
 		pay[i] = 0x0f
 	}
@@ -110,7 +109,7 @@ func Test_LargePacket(t *testing.T) {
 		go func() {
 			slc := bytes.NewBuffer([]byte{})
 			_, _ = pub.EncodeTo(slc)
-			_, err := DecodePacket(slc)
+			_, err := DecodePacket(slc,65536)
 			if err != nil {
 				t.Error(err)
 			}
@@ -123,7 +122,7 @@ func Test_LargePacket(t *testing.T) {
 func encodeTestHelper(toEncode Message) bool {
 	buf := bytes.NewBuffer([]byte{})
 	_, _ = toEncode.EncodeTo(buf)
-	msg, err := DecodePacket(buf)
+	msg, err := DecodePacket(buf,65536)
 	if err != nil {
 		log.Printf("error in here %+v\n", err.Error())
 		return false
@@ -231,7 +230,7 @@ func Test_Publish2(t *testing.T) {
 	}
 	buf := bytes.NewBuffer([]byte{})
 	_, _ = testPkt.EncodeTo(buf)
-	msg, err := DecodePacket(buf)
+	msg, err := DecodePacket(buf,65536)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -256,7 +255,7 @@ func Test_Publish_WithUnicodeDecoding(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	_, _ = testPkt.EncodeTo(buf)
 
-	msg, err := DecodePacket(buf)
+	msg, err := DecodePacket(buf,65536)
 	if err != nil {
 		t.Error(err.Error())
 	}


### PR DESCRIPTION
As of now maximum message size is fixed to default 64KB. If a message arrives which is bigger than this the connection is dropped. 
So adding max message size as configurable would let users fine tune the max size.