### PR TITLE
Added support for shared subscriptions

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -13,8 +13,8 @@ environment:
 install:  
   - set PATH=%GOPATH%\bin;c:\go\bin;%PATH%
   - rmdir c:\go /s /q
-  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.11.windows-amd64.zip
-  - 7z x go1.11.windows-amd64.zip -y -oC:\ > NUL
+  - appveyor DownloadFile https://storage.googleapis.com/golang/go1.12.windows-amd64.zip
+  - 7z x go1.12.windows-amd64.zip -y -oC:\ > NUL
   - go version
   - go get golang.org/x/tools/cmd/cover
   - go get github.com/mattn/goveralls

--- a/go.mod
+++ b/go.mod
@@ -16,6 +16,7 @@ require (
 	github.com/gorilla/websocket v1.4.0
 	github.com/jmespath/go-jmespath v0.0.0-20180206201540-c2b33e8439af // indirect
 	github.com/kelindar/binary v1.0.1
+	github.com/kelindar/rand v1.0.1
 	github.com/kelindar/tcp v0.0.0-20170901060004-951ea01d26dd
 	github.com/pkg/errors v0.0.0-20181008045315-2233dee583dc // indirect
 	github.com/stretchr/objx v0.0.0-20180825064932-ef50b0de2877 // indirect

--- a/go.sum
+++ b/go.sum
@@ -34,6 +34,10 @@ github.com/kelindar/binary v1.0.1 h1:618UzNUN9ckT2CeGcRF4N8q/0WWtvcpVL6O1DDfCXUM
 github.com/kelindar/binary v1.0.1/go.mod h1:wMMTJccK3HLFh6eH9bD4VRIjUTFVW7pC1q0vTUQ7vV8=
 github.com/kelindar/process v0.0.0-20170730150328-69a29e249ec3 h1:6If+E1dikQbdT7DlhZqLplfGkEt6dSoz7+MK+TFC7+U=
 github.com/kelindar/process v0.0.0-20170730150328-69a29e249ec3/go.mod h1:+lTCLnZFXOkqwD8sLPl6u4erAc0cP8wFegQHfipz7KE=
+github.com/kelindar/rand v1.0.0 h1:bbNIldIvDRhql45OjzwYvkDZV9ANExnxt295UpmIvUQ=
+github.com/kelindar/rand v1.0.0/go.mod h1:Ps9zsneYaqEckQIYsC/6I/VkYv+zVEGeUXs/WQIGpWw=
+github.com/kelindar/rand v1.0.1 h1:PfCe86AM7iprR8lWOj4AWiYcdbT+b3iaLmFMRxjjihc=
+github.com/kelindar/rand v1.0.1/go.mod h1:Ps9zsneYaqEckQIYsC/6I/VkYv+zVEGeUXs/WQIGpWw=
 github.com/kelindar/tcp v0.0.0-20170901060004-951ea01d26dd h1:db4hk9Jwj8GBRIeBEOJh9OiwcuYRbqXhuX5JNmCHRoc=
 github.com/kelindar/tcp v0.0.0-20170901060004-951ea01d26dd/go.mod h1:JB5hj1cshLU60XrLij2BBxW3JQ4hOye8vqbyvuKb52k=
 github.com/klauspost/compress v1.4.0 h1:8nsMz3tWa9SWWPL60G1V6CUsf4lLjWLTNEtibhe8gh8=

--- a/internal/broker/handlers.go
+++ b/internal/broker/handlers.go
@@ -405,7 +405,7 @@ func (s *Service) OnSurvey(queryType string, payload []byte) ([]byte, bool) {
 // lookupPresence performs a subscriptions lookup and returns a presence information.
 func (s *Service) lookupPresence(ssid message.Ssid) []presenceInfo {
 	resp := make([]presenceInfo, 0, 4)
-	for _, subscriber := range s.subscriptions.Lookup(ssid) {
+	for _, subscriber := range s.subscriptions.Lookup(ssid, nil) {
 		if conn, ok := subscriber.(*Conn); ok {
 			resp = append(resp, presenceInfo{
 				ID:       conn.ID(),

--- a/internal/broker/handlers_test.go
+++ b/internal/broker/handlers_test.go
@@ -204,7 +204,7 @@ func TestHandlers_onSubscribeUnsubscribe(t *testing.T) {
 			channel := security.ParseChannel([]byte(tc.channel))
 			key, _ := s.Cipher.DecryptKey(channel.Key)
 			ssid := message.NewSsid(key.Contract(), channel.Query)
-			subscribers := s.subscriptions.Lookup(ssid)
+			subscribers := s.subscriptions.Lookup(ssid, nil)
 			assert.Equal(t, tc.subCount, len(subscribers))
 
 			// Unsubscribe and check for error.
@@ -212,7 +212,7 @@ func TestHandlers_onSubscribeUnsubscribe(t *testing.T) {
 			assert.Equal(t, tc.unsubErr, unsubErr, tc.msg)
 
 			// Search for the ssid.
-			subscribers = s.subscriptions.Lookup(ssid)
+			subscribers = s.subscriptions.Lookup(ssid, nil)
 			assert.Equal(t, tc.unsubCount, len(subscribers))
 		})
 	}

--- a/internal/broker/service.go
+++ b/internal/broker/service.go
@@ -394,7 +394,7 @@ func (s *Service) onSubscribe(ssid message.Ssid, sub message.Subscriber) bool {
 
 // Occurs when a peer has unsubscribed.
 func (s *Service) onUnsubscribe(ssid message.Ssid, sub message.Subscriber) (ok bool) {
-	subscribers := s.subscriptions.Lookup(ssid)
+	subscribers := s.subscriptions.Lookup(ssid, nil)
 	if ok = subscribers.Contains(sub); ok {
 		s.subscriptions.Unsubscribe(ssid, sub)
 
@@ -407,21 +407,27 @@ func (s *Service) onUnsubscribe(ssid message.Ssid, sub message.Subscriber) (ok b
 func (s *Service) onPeerMessage(m *message.Message) {
 	defer s.measurer.MeasureElapsed("peer.msg", time.Now())
 
+	// Iterate through all subscribers and send them the message
+	size, n := len(m.Payload), 0
+	filter := func(s message.Subscriber) bool {
+		return s.Type() == message.SubscriberDirect // only local subscribers
+	}
+
+	// Find the lookup method to execute
+	lookup := s.subscriptions.Lookup
+	if m.ID.Share() {
+		lookup = s.subscriptions.Random
+	}
+
+	for _, subscriber := range lookup(m.Ssid(), filter) {
+		subscriber.Send(m)
+		n += size
+	}
+
 	// Get the contract
 	contract, contractFound := s.contracts.Get(m.Contract())
-
-	// Iterate through all subscribers and send them the message
-	for _, subscriber := range s.subscriptions.Lookup(m.Ssid()) {
-		if subscriber.Type() == message.SubscriberDirect {
-
-			// Send to the local subscriber
-			subscriber.Send(m)
-
-			// Write the egress stats
-			if contractFound {
-				contract.Stats().AddEgress(int64(len(m.Payload)))
-			}
-		}
+	if contractFound {
+		contract.Stats().AddEgress(int64(n))
 	}
 }
 
@@ -438,17 +444,23 @@ func (s *Service) Survey(query string, payload []byte) (message.Awaiter, error) 
 // Publish publishes a message to everyone and returns the number of outgoing bytes written.
 func (s *Service) publish(m *message.Message, exclude string) (n int64) {
 	size := m.Size()
-	for _, subscriber := range s.subscriptions.Lookup(m.Ssid()) {
-		if subscriber.ID() != exclude {
-			subscriber.Send(m)
-		}
+	filter := func(s message.Subscriber) bool {
+		return s.ID() != exclude
+	}
 
-		// Increment the egress size only for direct subscribers
+	// Find the lookup method to execute
+	lookup := s.subscriptions.Lookup
+	if m.ID.Share() {
+		lookup = s.subscriptions.Random
+	}
+
+	// Run the lookup and send the message
+	for _, subscriber := range lookup(m.Ssid(), filter) {
+		subscriber.Send(m)
 		if subscriber.Type() == message.SubscriberDirect {
 			n += size
 		}
 	}
-
 	return
 }
 

--- a/internal/message/id.go
+++ b/internal/message/id.go
@@ -94,6 +94,11 @@ func (id ID) Ssid() Ssid {
 	return ssid
 }
 
+// Share returns whether the message is for a shared subscription or not.
+func (id ID) Share() bool {
+	return binary.BigEndian.Uint32(id[fixed+4:fixed+8]) == share
+}
+
 // HasPrefix matches the prefix with the cutoff time.
 func (id ID) HasPrefix(ssid Ssid, cutoff int64) bool {
 	return (binary.BigEndian.Uint32(id[0:4]) == ssid[0]^ssid[1]) && id.Time() >= cutoff

--- a/internal/message/id.go
+++ b/internal/message/id.go
@@ -94,11 +94,6 @@ func (id ID) Ssid() Ssid {
 	return ssid
 }
 
-// Share returns whether the message is for a shared subscription or not.
-func (id ID) Share() bool {
-	return binary.BigEndian.Uint32(id[fixed+4:fixed+8]) == share
-}
-
 // HasPrefix matches the prefix with the cutoff time.
 func (id ID) HasPrefix(ssid Ssid, cutoff int64) bool {
 	return (binary.BigEndian.Uint32(id[0:4]) == ssid[0]^ssid[1]) && id.Time() >= cutoff

--- a/internal/message/id_test.go
+++ b/internal/message/id_test.go
@@ -30,7 +30,6 @@ func TestID_NewID(t *testing.T) {
 
 	id.SetTime(offset + 1)
 	assert.Equal(t, int64(offset+1), id.Time())
-	assert.True(t, id.Share())
 }
 
 func TestID_NewPrefix(t *testing.T) {

--- a/internal/message/id_test.go
+++ b/internal/message/id_test.go
@@ -23,13 +23,14 @@ import (
 
 func TestID_NewID(t *testing.T) {
 	next = math.MaxUint32
-	id := NewID(Ssid{1, 2, 3})
+	id := NewID(Ssid{1, share, 3})
 
 	assert.Zero(t, next)
 	assert.True(t, id.Time() > 1527819700)
 
 	id.SetTime(offset + 1)
 	assert.Equal(t, int64(offset+1), id.Time())
+	assert.True(t, id.Share())
 }
 
 func TestID_NewPrefix(t *testing.T) {

--- a/internal/message/sub.go
+++ b/internal/message/sub.go
@@ -55,6 +55,15 @@ func NewSsidForPresence(original Ssid) Ssid {
 	return ssid
 }
 
+// NewSsidForShare creates a new SSID for shared subscriptions.
+func NewSsidForShare(original Ssid) Ssid {
+	ssid := make([]uint32, 0, len(original)+1)
+	ssid = append(ssid, original[0])
+	ssid = append(ssid, share)
+	ssid = append(ssid, original[1:]...)
+	return ssid
+}
+
 // Contract gets the contract part from SSID.
 func (s Ssid) Contract() uint32 {
 	return uint32(s[0])

--- a/internal/message/sub.go
+++ b/internal/message/sub.go
@@ -28,6 +28,7 @@ const (
 	presence = uint32(3869262148)
 	query    = uint32(3939663052)
 	wildcard = uint32(1815237614)
+	share    = uint32(1480642916)
 )
 
 // Query represents a constant SSID for a query.

--- a/internal/message/sub_test.go
+++ b/internal/message/sub_test.go
@@ -23,6 +23,12 @@ func TestSsidPresence(t *testing.T) {
 	assert.EqualValues(t, Ssid{0, 3869262148, 1, 2, 3}, ssid)
 }
 
+func TestSsidShare(t *testing.T) {
+	ssid := NewSsidForShare(Ssid{1, 2, 3})
+	assert.NotNil(t, ssid)
+	assert.EqualValues(t, Ssid{1, share, 2, 3}, ssid)
+}
+
 func TestSsid(t *testing.T) {
 	c := security.Channel{
 		Key:         []byte("key"),

--- a/internal/message/subtrie.go
+++ b/internal/message/subtrie.go
@@ -16,6 +16,8 @@ package message
 
 import (
 	"sync"
+
+	"github.com/kelindar/rand"
 )
 
 type node struct {
@@ -114,18 +116,32 @@ func (t *Trie) Unsubscribe(ssid Ssid, subscriber Subscriber) {
 }
 
 // Lookup returns the Subscribers for the given topic.
-func (t *Trie) Lookup(query Ssid) (subs Subscribers) {
+func (t *Trie) Lookup(query Ssid, filter func(s Subscriber) bool) (subs Subscribers) {
 	t.RLock()
-	t.lookup(query, &subs, t.root)
+	t.lookup(query, &subs, t.root, filter)
 	t.RUnlock()
 	return
 }
 
-func (t *Trie) lookup(query Ssid, subs *Subscribers, node *node) {
+// Random picks a random subscriber.
+func (t *Trie) Random(query Ssid, filter func(s Subscriber) bool) (subs Subscribers) {
+	t.RLock()
+	t.lookup(query, &subs, t.root, filter)
+	t.RUnlock()
+	if len(subs) > 0 {
+		x := rand.Uint32n(uint32(len(subs)))
+		subs = subs[x : x+1]
+	}
+	return
+}
+
+func (t *Trie) lookup(query Ssid, subs *Subscribers, node *node, filter func(s Subscriber) bool) {
 
 	// Add subscribers from the current branch
 	for _, s := range node.subs {
-		subs.AddUnique(s)
+		if filter == nil || filter(s) {
+			subs.AddUnique(s)
+		}
 	}
 
 	// If we're not yet done, continue
@@ -133,12 +149,12 @@ func (t *Trie) lookup(query Ssid, subs *Subscribers, node *node) {
 
 		// Go through the exact match branch
 		if n, ok := node.children[query[0]]; ok {
-			t.lookup(query[1:], subs, n)
+			t.lookup(query[1:], subs, n, filter)
 		}
 
 		// Go through wildcard match branc
 		if n, ok := node.children[wildcard]; ok {
-			t.lookup(query[1:], subs, n)
+			t.lookup(query[1:], subs, n, filter)
 		}
 	}
 }

--- a/internal/message/subtrie.go
+++ b/internal/message/subtrie.go
@@ -119,7 +119,7 @@ func (t *Trie) Unsubscribe(ssid Ssid, subscriber Subscriber) {
 func (t *Trie) Lookup(ssid Ssid, filter func(s Subscriber) bool) (subs Subscribers) {
 	t.RLock()
 	t.lookup(ssid, &subs, t.root, filter)
-	if contractNode, ok := t.root.children[ssid[0]]; ok && len(ssid) >= 4 {
+	if contractNode, ok := t.root.children[ssid[0]]; ok {
 		if shareNode, ok := contractNode.children[share]; ok {
 			t.randomByGroup(ssid[1:], &subs, shareNode, filter)
 		}

--- a/internal/message/subtrie_test.go
+++ b/internal/message/subtrie_test.go
@@ -48,14 +48,18 @@ func TestTrieMatch1(t *testing.T) {
 func TestTrieMatch(t *testing.T) {
 	m := NewTrie()
 	testPopulateWithStrings(m, []string{
-		"a/",
-		"a/b/c/",
-		"a/+/c/",
-		"a/b/c/d/",
-		"a/+/c/+/",
-		"x/",
-		"x/y/",
-		"x/+/z",
+		"key/a/",
+		"key/a/b/c/",
+		"key/a/+/c/",
+		"key/a/b/c/d/",
+		"key/a/+/c/+/",
+		"key/x/",
+		"key/x/y/",
+		"key/x/+/z",
+		"key/$share/group1/a/+/c/",
+		"key/$share/group1/a/b/c/",
+		"key/$share/group2/a/b/c/",
+		"key/$share/group2/a/b/",
 	})
 
 	// Tests to run
@@ -63,23 +67,23 @@ func TestTrieMatch(t *testing.T) {
 		topic string
 		n     int
 	}{
-		{topic: "a/", n: 1},
-		{topic: "a/1/", n: 1},
-		{topic: "a/2/", n: 1},
-		{topic: "a/1/2/", n: 1},
-		{topic: "a/1/2/3/", n: 1},
-		{topic: "a/x/y/c/", n: 1},
-		{topic: "a/x/c/", n: 2},
-		{topic: "a/b/c/", n: 3},
-		{topic: "a/b/c/d/", n: 5},
-		{topic: "a/b/c/e/", n: 4},
-		{topic: "x/y/c/e/", n: 2},
+		{topic: "key/a/", n: 1},
+		{topic: "key/a/1/", n: 1},
+		{topic: "key/a/2/", n: 1},
+		{topic: "key/a/1/2/", n: 1},
+		{topic: "key/a/1/2/3/", n: 1},
+		{topic: "key/a/x/y/c/", n: 1},
+		{topic: "key/a/x/c/", n: 3},
+		{topic: "key/a/b/c/", n: 5},
+		{topic: "key/a/b/c/d/", n: 7},
+		{topic: "key/a/b/c/e/", n: 6},
+		{topic: "key/x/y/c/e/", n: 2},
 	}
 
-	assert.Equal(t, 8, m.Count())
+	assert.Equal(t, 12, m.Count())
 	for _, tc := range tests {
 		result := m.Lookup(testSub(tc.topic), nil)
-		assert.Equal(t, tc.n, len(result))
+		assert.Equal(t, tc.n, len(result), tc.topic)
 	}
 }
 
@@ -129,39 +133,6 @@ func TestTrieIntegration(t *testing.T) {
 	assertEqual(assert, []Subscriber{}, m.Lookup([]uint32{4, 5}, nil))
 	assertEqual(assert, []Subscriber{}, m.Lookup([]uint32{1, 5}, nil))
 	assertEqual(assert, []Subscriber{}, m.Lookup([]uint32{4}, nil))
-}
-
-func TestTrieRandom(t *testing.T) {
-	m := NewTrie()
-	testPopulateWithStrings(m, []string{
-		"$share/a/",
-		"$share/a/b/c/",
-		"$share/a/+/c/",
-		"$share/a/b/c/d/",
-		"$share/a/+/c/+/",
-		"$share/x/",
-		"$share/x/y/",
-		"$share/x/+/z",
-	})
-
-	// Tests to run
-	tests := []struct {
-		topic string
-		n     int
-	}{
-		{topic: "$share/z/", n: 0},
-		{topic: "$share/a/", n: 1},
-		{topic: "$share/a/b/c/", n: 1},
-		{topic: "$share/a/b/c/d/", n: 1},
-		{topic: "$share/a/b/c/e/", n: 1},
-		{topic: "$share/x/y/c/e/", n: 1},
-	}
-
-	assert.Equal(t, 8, m.Count())
-	for _, tc := range tests {
-		result := m.Random(testSub(tc.topic), nil)
-		assert.Equal(t, tc.n, len(result))
-	}
 }
 
 // Populates the trie with a set of strings
@@ -214,6 +185,7 @@ func BenchmarkSubscriptionTrieUnsubscribe(b *testing.B) {
 	}
 }
 
+// BenchmarkSubscriptionTrieLookup-8   	10000000	       168 ns/op	      16 B/op	       1 allocs/op
 func BenchmarkSubscriptionTrieLookup(b *testing.B) {
 	var (
 		m  = NewTrie()

--- a/internal/message/subtrie_test.go
+++ b/internal/message/subtrie_test.go
@@ -60,6 +60,8 @@ func TestTrieMatch(t *testing.T) {
 		"key/$share/group1/a/b/c/",
 		"key/$share/group2/a/b/c/",
 		"key/$share/group2/a/b/",
+		"key/$share/group3/y/",
+		"key/$share/group3/y/",
 	})
 
 	// Tests to run
@@ -78,9 +80,10 @@ func TestTrieMatch(t *testing.T) {
 		{topic: "key/a/b/c/d/", n: 7},
 		{topic: "key/a/b/c/e/", n: 6},
 		{topic: "key/x/y/c/e/", n: 2},
+		{topic: "key/y/", n: 1},
 	}
 
-	assert.Equal(t, 12, m.Count())
+	assert.Equal(t, 14, m.Count())
 	for _, tc := range tests {
 		result := m.Lookup(testSub(tc.topic), nil)
 		assert.Equal(t, tc.n, len(result), tc.topic)

--- a/internal/security/channel.go
+++ b/internal/security/channel.go
@@ -231,7 +231,7 @@ func (c *Channel) parseChannel(text []byte) (i int) {
 			continue
 
 		// Valid character, but nothing special
-		case (symbol >= 45 && symbol <= 58) || (symbol >= 65 && symbol <= 122):
+		case (symbol >= 45 && symbol <= 58) || (symbol >= 65 && symbol <= 122) || symbol == 36:
 			if wildcards > 0 {
 				c.ChannelType = ChannelInvalid
 				return i

--- a/internal/security/channel_test.go
+++ b/internal/security/channel_test.go
@@ -207,6 +207,7 @@ func TestGetChannelTarget(t *testing.T) {
 		target  uint32
 	}{
 		{channel: "emitter/a/?ttl=42&abc=9", target: 0xc103eab3},
+		{channel: "emitter/$share/a/b/c/", target: 1480642916},
 	}
 
 	for _, tc := range tests {

--- a/internal/security/hash/murmur_test.go
+++ b/internal/security/hash/murmur_test.go
@@ -36,6 +36,11 @@ func TestMeHash(t *testing.T) {
 	assert.Equal(t, uint32(2539734036), h)
 }
 
+func TestShareHash(t *testing.T) {
+	h := Of([]byte("$share"))
+	assert.Equal(t, uint32(1480642916), h)
+}
+
 func TestLinkHash(t *testing.T) {
 	h := Of([]byte("link"))
 	assert.Equal(t, uint32(2667034312), h)


### PR DESCRIPTION
A shared subscription is a mechanism for distributing messages to a set of subscribers to shared subscription topic, such that each message is received by only one subscriber. This contrasts with normal subscriptions where each subscriber will receive a copy of the published message.

 A shared subscription is on the form `$share/sharename/channel` and subscribers to this topic will receive messages published to the channel. The messages will be distributed according to the defined distribution policy.

![image](https://user-images.githubusercontent.com/583116/53567141-44187780-3b99-11e9-8003-a7f65fd6fa11.png)

