### PR TITLE
Fix function comments based on best practices from Effective Go

### DIFF
--- a/internal/provider/contract/contract.go
+++ b/internal/provider/contract/contract.go
@@ -59,7 +59,7 @@ func (c *contract) Validate(key security.Key) bool {
 		c.State == ContractStateAllowed
 }
 
-// Gets the usage statistics.
+// Stats gets the usage statistics.
 func (c *contract) Stats() usage.Meter {
 	return c.stats
 }

--- a/internal/provider/usage/usage.go
+++ b/internal/provider/usage/usage.go
@@ -72,7 +72,7 @@ func (t *usage) AddDevice(addr string) {
 	t.Devices.Insert([]byte(addr))
 }
 
-// Returns the estimated number of devices.
+// DeviceCount returns the estimated number of devices.
 func (t *usage) DeviceCount() int {
 	t.Lock.Lock()
 	defer t.Lock.Unlock()


### PR DESCRIPTION
Hi, we updated some exported function comments based on best practices from [Effective Go](https://golang.org/doc/effective_go.html#commentary). It’s admittedly a relatively minor fix up. Does this help you?