### PR TITLE
Implemented HTTP /keycheck method to verify key permissions and expiration

### DIFF
--- a/internal/broker/handlers_dto.go
+++ b/internal/broker/handlers_dto.go
@@ -154,6 +154,34 @@ func (r *meResponse) ForRequest(id uint16) {
 
 // ------------------------------------------------------------------------------------
 
+type keyCheckRequest struct {
+	Key     string `json:"key"`     // The key for this request.
+	Channel string `json:"channel"` // The channel to test with this request.
+}
+
+// ------------------------------------------------------------------------------------
+
+type keyCheckResponse struct {
+	Status            string              `json:"status"`             // The textual status of this response.
+	Expires           int64               `json:"expires"`            // The expiration UNIX timestamp
+	ExpiresText       string              `json:"expires_text"`       // The expiration in text format
+	ChannelAccessible bool                `json:"channel_accessible"` // Specifies that the given channel is accessible with the given key
+	Permissions       keyCheckPermissions `json:"permissions"`        // The permissions associated with the key
+}
+
+type keyCheckPermissions struct {
+	Master   bool `json:"master"`   // Specifies Master key permissions
+	Read     bool `json:"read"`     // Specifies Read key permissions
+	Write    bool `json:"write"`    // Specifies Write key permissions
+	Store    bool `json:"store"`    // Specifies Store key permissions
+	Load     bool `json:"load"`     // Specifies Load key permissions
+	Presence bool `json:"presence"` // Specifies Presence key permissions
+	Extend   bool `json:"extend"`   // Specifies Extend key permissions
+	Execute  bool `json:"execute"`  // Specifies Execute key permissions
+}
+
+// ------------------------------------------------------------------------------------
+
 type presenceRequest struct {
 	Key     string `json:"key"`     // The channel key for this request.
 	Channel string `json:"channel"` // The target channel for this request.

--- a/internal/broker/service_test.go
+++ b/internal/broker/service_test.go
@@ -176,7 +176,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read pong
-		pkt, err := mqtt.DecodePacket(cli,65536)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPingresp, pkt.Type())
 	}
@@ -203,7 +203,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read the retained message
-		pkt, err := mqtt.DecodePacket(cli,65536)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPublish, pkt.Type())
 		assert.Equal(t, &mqtt.Publish{
@@ -214,7 +214,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read suback
-		pkt, err := mqtt.DecodePacket(cli,65536)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfSuback, pkt.Type())
 	}
@@ -230,7 +230,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read the message back
-		pkt, err := mqtt.DecodePacket(cli,65536)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPublish, pkt.Type())
 		assert.Equal(t, &mqtt.Publish{
@@ -262,7 +262,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read unsuback
-		pkt, err := mqtt.DecodePacket(cli,65536)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfUnsuback, pkt.Type())
 	}
@@ -278,7 +278,7 @@ func TestPubsub(t *testing.T) {
 	}
 
 	{ // Read the link response
-		pkt, err := mqtt.DecodePacket(cli,65536)
+		pkt, err := mqtt.DecodePacket(cli, 65536)
 		assert.NoError(t, err)
 		assert.Equal(t, mqtt.TypeOfPublish, pkt.Type())
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -27,9 +27,9 @@ import (
 
 // Constants used throughout the service.
 const (
-	ChannelSeparator         = '/'   // The separator character.
-	maxMessageSize           = 65536 // Default Maximum message size allowed from/to the peer.
-	EncodingBufferSize       = 65536 // Initial buffer size for encoding buffers
+	ChannelSeparator   = '/'   // The separator character.
+	maxMessageSize     = 65536 // Default Maximum message size allowed from/to the peer.
+	EncodingBufferSize = 65536 // Initial buffer size for encoding buffers
 )
 
 // VaultUser is the vault user to use for authentication
@@ -83,27 +83,26 @@ func New(filename string, stores ...cfg.SecretStore) *Config {
 
 // Config represents main configuration.
 type Config struct {
-	ListenAddr     string              `json:"listen"`             // The API port used for TCP & Websocket communication.
-	License        string              `json:"license"`            // The license file to use for the broker.
-	Limit		   *LimitConfig        `json:"limit,omitempty"`    // Configuration for various limits such as message size.
-	TLS            *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
-	Cluster        *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.
-	Storage        *cfg.ProviderConfig `json:"storage,omitempty"`  // The configuration for the storage provider.
-	Contract       *cfg.ProviderConfig `json:"contract,omitempty"` // The configuration for the contract provider.
-	Metering       *cfg.ProviderConfig `json:"metering,omitempty"` // The configuration for the usage storage for metering.
-	Logging        *cfg.ProviderConfig `json:"logging,omitempty"`  // The configuration for the logger.
-	Monitor        *cfg.ProviderConfig `json:"monitor,omitempty"`  // The configuration for the monitoring storage.
-	Vault          secretStoreConfig   `json:"vault,omitempty"`    // The configuration for the Hashicorp Vault Secret Store.
-	Dynamo         secretStoreConfig   `json:"dynamodb,omitempty"` // The configuration for the AWS DynamoDB Secret Store.
+	ListenAddr string              `json:"listen"`             // The API port used for TCP & Websocket communication.
+	License    string              `json:"license"`            // The license file to use for the broker.
+	Limit      *LimitConfig        `json:"limit,omitempty"`    // Configuration for various limits such as message size.
+	TLS        *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
+	Cluster    *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.
+	Storage    *cfg.ProviderConfig `json:"storage,omitempty"`  // The configuration for the storage provider.
+	Contract   *cfg.ProviderConfig `json:"contract,omitempty"` // The configuration for the contract provider.
+	Metering   *cfg.ProviderConfig `json:"metering,omitempty"` // The configuration for the usage storage for metering.
+	Logging    *cfg.ProviderConfig `json:"logging,omitempty"`  // The configuration for the logger.
+	Monitor    *cfg.ProviderConfig `json:"monitor,omitempty"`  // The configuration for the monitoring storage.
+	Vault      secretStoreConfig   `json:"vault,omitempty"`    // The configuration for the Hashicorp Vault Secret Store.
+	Dynamo     secretStoreConfig   `json:"dynamodb,omitempty"` // The configuration for the AWS DynamoDB Secret Store.
 
 	listenAddr *net.TCPAddr     // The listen address, parsed.
 	certCaches []cfg.CertCacher // The certificate caches configured.
 }
 
-
-func (c *Config) MaxMessageBytes() int64{
+func (c *Config) MaxMessageBytes() int64 {
 	//return default if not configured
-	if c.Limit == nil || c.Limit.MessageSize <= 0{
+	if c.Limit == nil || c.Limit.MessageSize <= 0 {
 		return maxMessageSize
 	}
 	return int64(c.Limit.MessageSize)
@@ -160,7 +159,7 @@ type ClusterConfig struct {
 }
 
 //Limit represent various limit configurations - such as message size.
-type LimitConfig struct{
+type LimitConfig struct {
 	//Maximum message size allowed from/to the peer. Default if not specified is 64kB.
 	MessageSize int `json:"messageSize,omitempty"`
 }

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -42,7 +42,7 @@ func Test_New(t *testing.T) {
 	assert.NotNil(t, c)
 }
 
-func Test_DefaultMaxMessageSize(t *testing.T){
+func Test_DefaultMaxMessageSize(t *testing.T) {
 	c := New("test.conf", dynamo.NewProvider())
 	defer os.Remove("test.conf")
 

--- a/internal/network/mqtt/mqtt_test.go
+++ b/internal/network/mqtt/mqtt_test.go
@@ -80,7 +80,7 @@ func benchmarkPacketDecode(b *testing.B, packet Message) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		reader.Seek(0, io.SeekStart)
-		_, err := DecodePacket(reader,65536)
+		_, err := DecodePacket(reader, 65536)
 		if err != nil {
 			b.Error(err)
 		}
@@ -109,7 +109,7 @@ func Test_LargePacket(t *testing.T) {
 		go func() {
 			slc := bytes.NewBuffer([]byte{})
 			_, _ = pub.EncodeTo(slc)
-			_, err := DecodePacket(slc,65536)
+			_, err := DecodePacket(slc, 65536)
 			if err != nil {
 				t.Error(err)
 			}
@@ -122,7 +122,7 @@ func Test_LargePacket(t *testing.T) {
 func encodeTestHelper(toEncode Message) bool {
 	buf := bytes.NewBuffer([]byte{})
 	_, _ = toEncode.EncodeTo(buf)
-	msg, err := DecodePacket(buf,65536)
+	msg, err := DecodePacket(buf, 65536)
 	if err != nil {
 		log.Printf("error in here %+v\n", err.Error())
 		return false
@@ -230,7 +230,7 @@ func Test_Publish2(t *testing.T) {
 	}
 	buf := bytes.NewBuffer([]byte{})
 	_, _ = testPkt.EncodeTo(buf)
-	msg, err := DecodePacket(buf,65536)
+	msg, err := DecodePacket(buf, 65536)
 	if err != nil {
 		t.Error(err.Error())
 	}
@@ -255,7 +255,7 @@ func Test_Publish_WithUnicodeDecoding(t *testing.T) {
 	buf := bytes.NewBuffer([]byte{})
 	_, _ = testPkt.EncodeTo(buf)
 
-	msg, err := DecodePacket(buf,65536)
+	msg, err := DecodePacket(buf, 65536)
 	if err != nil {
 		t.Error(err.Error())
 	}

--- a/internal/security/crypto_test.go
+++ b/internal/security/crypto_test.go
@@ -2,9 +2,10 @@ package security
 
 import (
 	"encoding/base64"
-	"github.com/stretchr/testify/assert"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 type x struct {


### PR DESCRIPTION
This PR introduces an HTTP POST endpoint at `/keycheck` which allows a user to check whether the given `key` can access the given `channel` and return the key permissions and expiration.  I mainly implemented this to ensure that a key that I was using did not have an expiration date, as a previous set that I had initially created recently expired and cause some major issues.  As far as I can tell, there is no way to verify the expiration date of a key using the client.  This PR does not seem any less secure than the HTTP `/presence` method (neither should be used without HTTPS).

To use the new method, send a `POST` request to `/keycheck` with body content like this:
```
{ "key": "abcdDc0UP9asdasdURH2ppKJckNo1234", "channel": "demo/foo/" }
```

The response looks something like this (piped through `jq` for clarity):
```
curl -sS -X POST --data '{ "key": "abcdDc0UP9asdasdURH2ppKJckNo1234", "channel": "demo/foo/" }' http://localhost:8080/keycheck | jq .

{
  "status": "OK",
  "expires": 1553640815,
  "expires_text": "2019-03-26 22:53:35 +0000 UTC",
  "channel_accessible": true,
  "permissions": {
    "master": false,
    "read": true,
    "write": true,
    "store": true,
    "load": false,
    "presence": false,
    "extend": true,
    "execute": false
  }
}
```

Not sure if this is useful for anyone else, but I couldn't find another way to check key expiration!  If you do want the feature, let me know and I will add documentation and tests.