### PR TITLE
optimised message frame encoding/decoding

### DIFF
--- a/internal/broker/cluster/peer.go
+++ b/internal/broker/cluster/peer.go
@@ -124,7 +124,8 @@ func (p *Peer) processSendQueue() {
 		return
 	}
 
-	// Swap the frame and encode it
+	// Swap the frame and encode it.
+	// TODO: split the frame in chunks of at most 10MB for gossip unicast to work.
 	frame := p.swap()
 	buffer := frame.Encode()
 

--- a/internal/broker/cluster/peer_test.go
+++ b/internal/broker/cluster/peer_test.go
@@ -16,6 +16,8 @@ func (s *stubGossip) GossipUnicast(dst mesh.PeerName, msg []byte) error {
 }
 
 // Benchmark_ProcessQueue-8   	    3000	    515299 ns/op	  407117 B/op	      18 allocs/op
+// Benchmark_ProcessQueue-8   	    5000	    296610 ns/op	  359599 B/op	      10 allocs/op
+// Benchmark_ProcessQueue-8   	    5000	    272677 ns/op	  215082 B/op	       7 allocs/op
 func Benchmark_ProcessQueue(b *testing.B) {
 	msg := newTestMessage(message.Ssid{1, 2, 3}, "a/b/c/", "hello abc")
 	s := new(Swarm)
@@ -32,7 +34,6 @@ func Benchmark_ProcessQueue(b *testing.B) {
 
 		p.processSendQueue()
 	}
-
 }
 
 func TestPeer_Multiple(t *testing.T) {

--- a/internal/message/message_test.go
+++ b/internal/message/message_test.go
@@ -63,7 +63,8 @@ func TestNewFrame(t *testing.T) {
 	assert.Equal(t, 64, cap(f))
 }
 
-// 2000000	       577 ns/op	     320 B/op	       2 allocs/op
+// BenchmarkEncode-8   	 2000000	       577 ns/op	     320 B/op	       2 allocs/op
+// BenchmarkEncode-8   	 3000000	       535 ns/op	     320 B/op	       3 allocs/op
 func BenchmarkEncode(b *testing.B) {
 	m := Frame{
 		newTestMessage(Ssid{1, 2, 3}, "tweet/canada/english/", "This is a random tweet en english so we can test the payload. #emitter"),
@@ -76,7 +77,8 @@ func BenchmarkEncode(b *testing.B) {
 	}
 }
 
-// 2000000	       799 ns/op	     480 B/op	       3 allocs/op
+// BenchmarkEncodeWithSnappy-8   	 2000000	       799 ns/op	     480 B/op	       3 allocs/op
+// BenchmarkEncodeWithSnappy-8   	 2000000	       628 ns/op	     224 B/op	       2 allocs/op
 func BenchmarkEncodeWithSnappy(b *testing.B) {
 	m := Frame{
 		newTestMessage(Ssid{1, 2, 3}, "tweet/canada/english/", "This is a random tweet en english so we can test the payload. #emitter"),
@@ -86,6 +88,22 @@ func BenchmarkEncodeWithSnappy(b *testing.B) {
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
 		m.Encode()
+	}
+}
+
+// Benchmark_DecodeFrame-8   	    3000	    487375 ns/op	  280592 B/op	    6005 allocs/op
+// Benchmark_DecodeFrame-8   	    3000	    488361 ns/op	  275317 B/op	    6004 allocs/op
+func Benchmark_DecodeFrame(b *testing.B) {
+	var frame Frame
+	for m := 0; m < 1000; m++ {
+		frame = append(frame, newTestMessage(Ssid{1, 2, 3}, "a/b/c/", "hello abc"))
+	}
+	encoded := frame.Encode()
+
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		DecodeFrame(encoded)
 	}
 }
 


### PR DESCRIPTION
Improved the performance encoding/decoding of frames by adding a buffer pool. This is safe, given the memory copy is performed during Snappy encoding anyway.