### PR TITLE
no-copy message encoding & fixed memory sort

### DIFF
--- a/internal/message/codec.go
+++ b/internal/message/codec.go
@@ -1,0 +1,69 @@
+/**********************************************************************************
+* Copyright (c) 2009-2019 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package message
+
+import (
+	"reflect"
+
+	"github.com/emitter-io/emitter/internal/collection"
+	"github.com/kelindar/binary"
+)
+
+// Reusable buffer pool.
+var bufferPool = collection.NewBufferPool(64 * 1024)
+
+type messageCodec struct{}
+
+// Encode encodes a value into the encoder.
+func (c *messageCodec) EncodeTo(e *binary.Encoder, rv reflect.Value) (err error) {
+	id := rv.Field(0).Bytes()
+	channel := rv.Field(1).Bytes()
+	payload := rv.Field(2).Bytes()
+	ttl := rv.Field(3).Uint()
+
+	e.WriteUvarint(uint64(len(id)))
+	e.Write(id)
+	e.WriteUvarint(uint64(len(channel)))
+	e.Write(channel)
+	e.WriteUvarint(uint64(len(payload)))
+	e.Write(payload)
+	e.WriteUvarint(ttl)
+	return
+}
+
+// Decode decodes into a reflect value from the decoder.
+func (c *messageCodec) DecodeTo(d *binary.Decoder, rv reflect.Value) (err error) {
+	var v Message
+	if v.ID, err = readBytes(d); err == nil {
+		if v.Channel, err = readBytes(d); err == nil {
+			if v.Payload, err = readBytes(d); err == nil {
+				if ttl, err := d.ReadUvarint(); err == nil {
+					v.TTL = uint32(ttl)
+					rv.Set(reflect.ValueOf(v))
+					return nil
+				}
+			}
+		}
+	}
+	return
+}
+
+func readBytes(d *binary.Decoder) (buffer []byte, err error) {
+	var l uint64
+	if l, err = d.ReadUvarint(); err == nil && l > 0 {
+		buffer, err = d.Slice(int(l))
+	}
+	return
+}

--- a/internal/message/codec_test.go
+++ b/internal/message/codec_test.go
@@ -1,0 +1,70 @@
+/**********************************************************************************
+* Copyright (c) 2009-2019 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package message
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/golang/snappy"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestCodec_Message(t *testing.T) {
+
+	for i := 0; i < 100; i++ {
+		t.Run("codec", func(t *testing.T) {
+			t.Parallel()
+			msg := newTestMessage(Ssid{1, 2, 3}, "a/b/c/", fmt.Sprintf("message number %v", i))
+			buffer := msg.Encode()
+			//assert.True(t, len(buffer) >= 57)
+			//assert.True(t, len(buffer) <= 58)
+
+			// Decode
+			output, err := DecodeMessage(buffer)
+			assert.NoError(t, err)
+			assert.Equal(t, msg, output)
+		})
+	}
+}
+
+func TestCodec_HappyPath(t *testing.T) {
+	frame := Frame{
+		newTestMessage(Ssid{1, 2, 3}, "a/b/c/", "hello abc"),
+		newTestMessage(Ssid{1, 2, 3}, "a/b/", "hello ab"),
+	}
+
+	// Encode
+	buffer := frame.Encode()
+	assert.True(t, len(buffer) >= 65)
+
+	// Decode
+	output, err := DecodeFrame(buffer)
+	assert.NoError(t, err)
+	assert.Equal(t, frame, output)
+}
+
+func TestCodec_Corrupt(t *testing.T) {
+	_, err := DecodeFrame([]byte{121, 4, 3, 2, 2, 1, 5, 3, 2})
+	assert.Equal(t, "snappy: corrupt input", err.Error())
+}
+
+func TestCodec_Invalid(t *testing.T) {
+	var out []byte
+	out = snappy.Encode(out, []byte{121, 4, 3, 2, 2, 1, 5, 3, 2})
+
+	_, err := DecodeFrame(out)
+	assert.Equal(t, "EOF", err.Error())
+}

--- a/internal/provider/storage/memory_test.go
+++ b/internal/provider/storage/memory_test.go
@@ -75,6 +75,12 @@ func TestInMemory_QueryOrdered(t *testing.T) {
 	testOrder(t, store)
 }
 
+func TestInMemory_QueryRange(t *testing.T) {
+	store := new(InMemory)
+	store.Configure(nil)
+	testRange(t, store)
+}
+
 func TestInMemory_QueryRetained(t *testing.T) {
 	store := new(InMemory)
 	store.Configure(nil)
@@ -137,6 +143,7 @@ func TestInMemory_Query(t *testing.T) {
 func TestInMemory_lookup(t *testing.T) {
 	s := newTestMemStore()
 	const wildcard = uint32(1815237614)
+	zero := time.Unix(0, 0)
 	tests := []struct {
 		query []uint32
 		limit int
@@ -151,13 +158,14 @@ func TestInMemory_lookup(t *testing.T) {
 	}
 
 	for _, tc := range tests {
-		matches := s.lookup(lookupQuery{Ssid: tc.query, Limit: tc.limit})
+		matches := s.lookup(newLookupQuery(tc.query, zero, zero, tc.limit))
 		assert.Equal(t, tc.count, len(matches))
 	}
 }
 
 func TestInMemory_OnSurvey(t *testing.T) {
 	s := newTestMemStore()
+	zero := time.Unix(0, 0)
 	tests := []struct {
 		name        string
 		query       lookupQuery
@@ -168,13 +176,13 @@ func TestInMemory_OnSurvey(t *testing.T) {
 		{name: "memstore"},
 		{
 			name:        "memstore",
-			query:       lookupQuery{Ssid: []uint32{0, 1}, Limit: 1},
+			query:       newLookupQuery(message.Ssid{0, 1}, zero, zero, 1),
 			expectOk:    true,
 			expectCount: 1,
 		},
 		{
 			name:        "memstore",
-			query:       lookupQuery{Ssid: []uint32{0, 1}, Limit: 10},
+			query:       newLookupQuery(message.Ssid{0, 1}, zero, zero, 10),
 			expectOk:    true,
 			expectCount: 6,
 		},

--- a/internal/provider/storage/ssd_test.go
+++ b/internal/provider/storage/ssd_test.go
@@ -91,6 +91,12 @@ func TestSSD_QueryRetained(t *testing.T) {
 	})
 }
 
+func TestSSD_QueryRange(t *testing.T) {
+	runSSDTest(func(store *SSD) {
+		testRange(t, store)
+	})
+}
+
 func TestSSD_QuerySurveyed(t *testing.T) {
 	runSSDTest(func(s *SSD) {
 		const wildcard = uint32(1815237614)

--- a/internal/provider/storage/storage_test.go
+++ b/internal/provider/storage/storage_test.go
@@ -110,6 +110,34 @@ func testRetained(t *testing.T, store Storage) {
 	assert.Equal(t, "9", string(f[0].Payload))
 }
 
+func testRange(t *testing.T, store Storage) {
+	var t0, t1 int64
+	for i := int64(0); i < 100; i++ {
+		msg := message.New(message.Ssid{0, 1, 2}, []byte("a/b/c/"), []byte(fmt.Sprintf("%d", i)))
+		msg.ID.SetTime(msg.ID.Time() + (i * 10000))
+		if i == 50 {
+			t0 = msg.ID.Time()
+		}
+		if i == 60 {
+			t1 = msg.ID.Time()
+		}
+
+		assert.NoError(t, store.Store(msg))
+	}
+
+	// Issue a query
+	f, err := store.Query([]uint32{0, 1, 2}, time.Unix(t0, 0), time.Unix(t1, 0), 5)
+	assert.NoError(t, err)
+
+	assert.Len(t, f, 5)
+	assert.Equal(t, message.Ssid{0, 1, 2}, f[0].Ssid())
+	assert.Equal(t, "56", string(f[0].Payload))
+	assert.Equal(t, "57", string(f[1].Payload))
+	assert.Equal(t, "58", string(f[2].Payload))
+	assert.Equal(t, "59", string(f[3].Payload))
+	assert.Equal(t, "60", string(f[4].Payload))
+}
+
 func Test_configUint32(t *testing.T) {
 	raw := `{
 		"provider": "memory",


### PR DESCRIPTION
A few changes with this PR:

1. We're using a zero copy codec in order to decrease memory allocations during encoding and decoding of message structs. This speeds up the decoding by 6x less allocations and effectively makes it 1 allocation per message per decode. Overall decoding time is reduced by around 2x.
2. Fixed a bug with in-memory message storage where messages would not be properly sorted, resulting in incorrect behavior.
3. All messages stored in both in-memory and ssd storages are now snappy compressed. This should result in less storage costs and faster storage altogether.
4. In-memory message storage now supports range queries and should have the same behavior as the SSD storage now.