### PR TITLE
Added debug mode configuration

### DIFF
--- a/internal/broker/bench_test.go
+++ b/internal/broker/bench_test.go
@@ -166,6 +166,7 @@ func newBenchClient(port int) *testConn {
 func newTestBroker(port int, licenseVersion int) *Service {
 	cfg := config.NewDefault().(*config.Config)
 	cfg.License = testLicense
+	cfg.Debug = true
 	if licenseVersion == 2 {
 		cfg.License = testLicenseV2
 	}

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ func New(filename string, stores ...cfg.SecretStore) *Config {
 type Config struct {
 	ListenAddr string              `json:"listen"`             // The API port used for TCP & Websocket communication.
 	License    string              `json:"license"`            // The license file to use for the broker.
+	Debug      bool                `json:"debug,omitempty"`    // The debug mode flag.
 	Limit      LimitConfig         `json:"limit,omitempty"`    // Configuration for various limits such as message size.
 	TLS        *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.
 	Cluster    *ClusterConfig      `json:"cluster,omitempty"`  // The configuration for the clustering.

--- a/main.go
+++ b/main.go
@@ -38,8 +38,8 @@ func main() {
 
 	// Register sub-commands
 	app.Command("load", "Runs the load testing client for emitter.", load.Run)
-	app.Command("license", "Manipulates licenses and secret keys.", func(config *cli.Cmd) {
-		config.Command("new", "Generates a new license and secret key pair.", license.New)
+	app.Command("license", "Manipulates licenses and secret keys.", func(cmd *cli.Cmd) {
+		cmd.Command("new", "Generates a new license and secret key pair.", license.New)
 		// TODO: add more sub-commands for license
 	})
 


### PR DESCRIPTION
This PR adds a debug mode flag in the config. Ppprof HTTP endpoints are now by default disabled and you'll need to flip the flag on to enable them.