### PR TITLE
Added a version command into the executable

### DIFF
--- a/build.bat
+++ b/build.bat
@@ -16,5 +16,5 @@ goto :end
 	set GOARCH=%2
 	go tool dist install pkg/runtime
 	go install -a std
-	go build -o build/emitter-%1-%2%3 -i .
+	go build -o build/emitter-%1-%2%3 -i  -ldflags "-X main.emitterVersion=%APPVEYOR_BUILD_VERSION% main.emitterCommit=%APPVEYOR_REPO_COMMIT%" .
 :end

--- a/build.bat
+++ b/build.bat
@@ -16,5 +16,5 @@ goto :end
 	set GOARCH=%2
 	go tool dist install pkg/runtime
 	go install -a std
-	go build -o build/emitter-%1-%2%3 -i  -ldflags "-X main.emitterVersion=%APPVEYOR_BUILD_VERSION% main.emitterCommit=%APPVEYOR_REPO_COMMIT%" .
+	go build -o build/emitter-%1-%2%3 -i  -ldflags "-X main.emitterVersion=%APPVEYOR_BUILD_VERSION% -X main.emitterCommit=%APPVEYOR_REPO_COMMIT%" .
 :end

--- a/internal/command/load/load_test.go
+++ b/internal/command/load/load_test.go
@@ -16,13 +16,13 @@ package load
 
 import (
 	"bytes"
-	"github.com/emitter-io/emitter/internal/network/mqtt"
 	"io"
 	"net"
 	"testing"
 	"time"
 
-	"github.com/jawher/mow.cli"
+	"github.com/emitter-io/emitter/internal/network/mqtt"
+	cli "github.com/jawher/mow.cli"
 	"github.com/stretchr/testify/assert"
 )
 

--- a/internal/command/version/version.go
+++ b/internal/command/version/version.go
@@ -1,0 +1,32 @@
+/**********************************************************************************
+* Copyright (c) 2009-2019 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package version
+
+import (
+	"fmt"
+
+	"github.com/emitter-io/emitter/internal/provider/logging"
+	cli "github.com/jawher/mow.cli"
+)
+
+// Print prints the version
+func Print(version, commit string) func(cmd *cli.Cmd) {
+	return func(cmd *cli.Cmd) {
+		cmd.Spec = ""
+		cmd.Action = func() {
+			logging.LogAction("version", fmt.Sprintf("emitter version v%s, commit %s", version, commit))
+		}
+	}
+}

--- a/internal/command/version/version_test.go
+++ b/internal/command/version/version_test.go
@@ -1,0 +1,36 @@
+/**********************************************************************************
+* Copyright (c) 2009-2019 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package version
+
+import (
+	"testing"
+
+	cli "github.com/jawher/mow.cli"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestNew(t *testing.T) {
+	assert.NotPanics(t, func() {
+		runCommand(Print("a", "b"))
+	})
+}
+
+func runCommand(f func(cmd *cli.Cmd), args ...string) {
+	app := cli.App("emitter", "")
+	app.Command("version", "", f)
+	v := []string{"emitter", "version"}
+	v = append(v, args...)
+	app.Run(v)
+}

--- a/main.go
+++ b/main.go
@@ -23,10 +23,14 @@ import (
 	"github.com/emitter-io/emitter/internal/broker"
 	"github.com/emitter-io/emitter/internal/command/license"
 	"github.com/emitter-io/emitter/internal/command/load"
+	"github.com/emitter-io/emitter/internal/command/version"
 	"github.com/emitter-io/emitter/internal/config"
 	"github.com/emitter-io/emitter/internal/provider/logging"
-	"github.com/jawher/mow.cli"
+	cli "github.com/jawher/mow.cli"
 )
+
+var emitterVersion string
+var emitterCommit string
 
 //go:generate go run internal/broker/generate/assets_gen.go
 
@@ -37,6 +41,7 @@ func main() {
 	app.Action = func() { listen(app, confPath) }
 
 	// Register sub-commands
+	app.Command("version", "Prints the version of the executable.", version.Print(emitterVersion, emitterCommit))
 	app.Command("load", "Runs the load testing client for emitter.", load.Run)
 	app.Command("license", "Manipulates licenses and secret keys.", func(cmd *cli.Cmd) {
 		cmd.Command("new", "Generates a new license and secret key pair.", license.New)


### PR DESCRIPTION
This PR introduces a `version` command which simply prints the version of the executable along with the git commit SHA. Use `emitter version` to run it.