### PR TITLE
Returning broker version on 'me' response

### DIFF
--- a/internal/broker/handlers.go
+++ b/internal/broker/handlers.go
@@ -20,6 +20,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/emitter-io/emitter/internal/command/version"
 	"github.com/emitter-io/emitter/internal/errors"
 	"github.com/emitter-io/emitter/internal/message"
 	"github.com/emitter-io/emitter/internal/network/mqtt"
@@ -279,9 +280,11 @@ func (c *Conn) onMe() (response, bool) {
 		links[k] = security.ParseChannel([]byte(v)).SafeString()
 	}
 
+	v, _ := version.Current()
 	return &meResponse{
-		ID:    c.ID(),
-		Links: links,
+		ID:     c.ID(),
+		Links:  links,
+		Broker: v,
 	}, true
 }
 

--- a/internal/broker/handlers_dto.go
+++ b/internal/broker/handlers_dto.go
@@ -113,6 +113,7 @@ func (r *linkResponse) ForRequest(id uint16) {
 type meResponse struct {
 	Request uint16            `json:"req,omitempty"`   // The corresponding request ID.
 	ID      string            `json:"id"`              // The private ID of the connection.
+	Broker  string            `json:"broker"`          // The version of the broker.
 	Links   map[string]string `json:"links,omitempty"` // The set of pre-defined channels.
 }
 

--- a/internal/command/version/version.go
+++ b/internal/command/version/version.go
@@ -33,3 +33,8 @@ func Print(cmd *cli.Cmd) {
 		logging.LogAction("version", fmt.Sprintf("emitter version %s, commit %s", version, commit))
 	}
 }
+
+// Current returns current version and git commit
+func Current() (string, string) {
+	return version, commit
+}

--- a/internal/command/version/version_test.go
+++ b/internal/command/version/version_test.go
@@ -27,6 +27,12 @@ func TestNew(t *testing.T) {
 	})
 }
 
+func TestCurrent(t *testing.T) {
+	v, c := Current()
+	assert.Equal(t, "0", v)
+	assert.Equal(t, "untracked", c)
+}
+
 func runCommand(f func(cmd *cli.Cmd), args ...string) {
 	app := cli.App("emitter", "")
 	app.Command("version", "", f)


### PR DESCRIPTION
This adds a `broker` field in `me` response which contains the version number of the broker.