### PR TITLE
Fixed alignment of int64, to be able to access it with atomic.LoadInt64

### DIFF
--- a/internal/broker/service.go
+++ b/internal/broker/service.go
@@ -51,6 +51,7 @@ import (
 
 // Service represents the main structure.
 type Service struct {
+	connections   int64                // The number of currently open connections.
 	context       context.Context      // The context for the service.
 	cancel        context.CancelFunc   // The cancellation function.
 	License       license.License      // The licence for this emitter server.
@@ -67,7 +68,6 @@ type Service struct {
 	monitor       monitor.Storage      // The storage provider for stats.
 	measurer      stats.Measurer       // The monitoring registry for the service.
 	metering      usage.Metering       // The usage storage for metering contracts.
-	connections   int64                // The number of currently open connections.
 }
 
 // NewService creates a new service.


### PR DESCRIPTION
On ARM (Raspberry Pi 3) following error occurs when starting emitter:
```
2019/12/09 11:54:58 [async] panic recovered: runtime error: invalid memory address or nil pointer dereferences
 goroutine 1 [running]:
runtime/debug.Stack(0x28fbaa4, 0xabcee0, 0x116b7a8)
        /usr/local/go/src/runtime/debug/stack.go:24 +0x78
github.com/emitter-io/emitter/internal/async.handlePanic()
        /go/src/github.com/emitter-io/emitter/internal/async/timer.go:58 +0x3c
panic(0xabcee0, 0x116b7a8)
        /usr/local/go/src/runtime/panic.go:679 +0x194
runtime/internal/atomic.goLoad64(0x2a3075c, 0xb6863e, 0xa)
        /usr/local/go/src/runtime/internal/atomic/atomic_arm.go:131 +0x1c
github.com/emitter-io/emitter/internal/broker.(*sampler).Snapshot(0x280ee00, 0x8, 0x2810b40, 0x0)
        /go/src/github.com/emitter-io/emitter/internal/broker/status.go:51 +0xec
github.com/emitter-io/emitter/internal/provider/monitor.(*Self).write(0x280d480)
        /go/src/github.com/emitter-io/emitter/internal/provider/monitor/self.go:80 +0x28
...
```
This is caused by a bug in the atomic package, which only allows to access 64-bit data fields if they are aligned. See https://golang.org/pkg/sync/atomic/#pkg-note-BUG
> On ARM, x86-32, and 32-bit MIPS, it is the caller's responsibility to arrange for 64-bit alignment of 64-bit words accessed atomically.

The bug descriptions also says, 
> The first word in a variable or in an allocated struct, array, or slice can be relied upon to be 64-bit aligned.

so I moved the field to the beginning of the struct.


