### PR TITLE
MQTT topic matching strategy

### DIFF
--- a/internal/broker/service.go
+++ b/internal/broker/service.go
@@ -79,11 +79,17 @@ type Service struct {
 // NewService creates a new service.
 func NewService(ctx context.Context, cfg *config.Config) (s *Service, err error) {
 	ctx, cancel := context.WithCancel(context.Background())
+	var trie *message.Trie
+	if "mqtt" == cfg.Matcher {
+		trie = message.NewTrieMQTT()
+	} else {
+		trie = message.NewTrie()
+	}
 	s = &Service{
 		context:       ctx,
 		cancel:        cancel,
 		Config:        cfg,
-		subscriptions: message.NewTrie(),
+		subscriptions: trie,
 		http:          new(http.Server),
 		tcp:           new(tcp.Server),
 		storage:       new(storage.Noop),

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -84,6 +84,7 @@ func New(filename string, stores ...cfg.SecretStore) *Config {
 type Config struct {
 	ListenAddr string              `json:"listen"`             // The API port used for TCP & Websocket communication.
 	License    string              `json:"license"`            // The license file to use for the broker.
+	Matcher    string              `json:"matcher,omitempty"`  // If "mqtt", then topic matching would follow MQTT specification.
 	Debug      bool                `json:"debug,omitempty"`    // The debug mode flag.
 	Limit      LimitConfig         `json:"limit,omitempty"`    // Configuration for various limits such as message size.
 	TLS        *cfg.TLSConfig      `json:"tls,omitempty"`      // The API port used for Secure TCP & Websocket communication.

--- a/internal/message/id.go
+++ b/internal/message/id.go
@@ -109,7 +109,7 @@ func (id ID) Match(query Ssid, from, until int64) bool {
 	// likelihood of having last element of SSID matching decreases with
 	// the depth of the SSID.
 	for i := len(query) - 1; i >= 0; i-- {
-		if query[i] != binary.BigEndian.Uint32(id[fixed+i*4:fixed+4+i*4]) && query[i] != wildcard {
+		if query[i] != binary.BigEndian.Uint32(id[fixed+i*4:fixed+4+i*4]) && query[i] != wildcard && query[i] != multiWildcard {
 			return false
 		}
 	}

--- a/internal/message/sub.go
+++ b/internal/message/sub.go
@@ -26,11 +26,12 @@ import (
 
 // Various constant parts of the SSID.
 const (
-	system   = uint32(0)
-	presence = uint32(3869262148)
-	query    = uint32(3939663052)
-	wildcard = uint32(1815237614)
-	share    = uint32(1480642916)
+	system        = uint32(0)
+	presence      = uint32(3869262148)
+	query         = uint32(3939663052)
+	wildcard      = uint32(1815237614) // +
+	multiWildcard = uint32(4285801373) // #
+	share         = uint32(1480642916)
 )
 
 // Query represents a constant SSID for a query.
@@ -86,7 +87,7 @@ func (s Ssid) Encode() string {
 	out := make([]byte, len(s)*8)
 
 	for i, v := range s {
-		if v != wildcard {
+		if v != wildcard && v != multiWildcard {
 			binary.BigEndian.PutUint32(bin, v)
 			hex.Encode(out[i*8:i*8+8], bin)
 		} else {

--- a/internal/security/channel.go
+++ b/internal/security/channel.go
@@ -221,7 +221,7 @@ func (c *Channel) parseChannel(text []byte) (i int) {
 			wildcards = 0
 			continue
 		// If this symbol is a wildcard symbol
-		case symbol == '+' || symbol == '*':
+		case symbol == '#' || symbol == '+' || symbol == '*':
 			if chanChars > 0 || wildcards > 0 {
 				c.ChannelType = ChannelInvalid
 				return i

--- a/internal/service/pubsub/subscribe.go
+++ b/internal/service/pubsub/subscribe.go
@@ -15,6 +15,7 @@
 package pubsub
 
 import (
+	"bytes"
 	"github.com/emitter-io/emitter/internal/errors"
 	"github.com/emitter-io/emitter/internal/event"
 	"github.com/emitter-io/emitter/internal/message"
@@ -40,6 +41,12 @@ func (s *Service) Subscribe(sub message.Subscriber, ev *event.Subscription) bool
 
 // OnSubscribe is a handler for MQTT Subscribe events.
 func (s *Service) OnSubscribe(c service.Conn, mqttTopic []byte) *errors.Error {
+
+	// compatibility with paho.mqtt.golang
+	// https://github.com/eclipse/paho.mqtt.golang/blob/master/topic.go#L78
+	// http://docs.oasis-open.org/mqtt/mqtt/v3.1.1/os/mqtt-v3.1.1-os.html#_Toc385349376
+	mqttTopic = bytes.ReplaceAll(mqttTopic, []byte("#"), []byte("#/"))
+	mqttTopic = bytes.ReplaceAll(mqttTopic, []byte("//"), []byte("/"))
 
 	// Parse the channel
 	channel := security.ParseChannel(mqttTopic)


### PR DESCRIPTION
I made a patch so the topic matching would follow MQTT specification.

emitter.conf
``` json
{
	"matcher": "mqtt"
}
```
or just run
```sh
EMITTER_MATCHER=mqtt ./emitter
```