### PR TITLE
[WIP] Add history api

### DIFF
--- a/internal/broker/service.go
+++ b/internal/broker/service.go
@@ -43,6 +43,7 @@ import (
 	"github.com/emitter-io/emitter/internal/security"
 	"github.com/emitter-io/emitter/internal/security/license"
 	"github.com/emitter-io/emitter/internal/service/cluster"
+	"github.com/emitter-io/emitter/internal/service/history"
 	"github.com/emitter-io/emitter/internal/service/keyban"
 	"github.com/emitter-io/emitter/internal/service/keygen"
 	"github.com/emitter-io/emitter/internal/service/link"
@@ -185,6 +186,7 @@ func NewService(ctx context.Context, cfg *config.Config) (s *Service, err error)
 	s.pubsub.Handle("keyban", keyban.New(s, s.keygen, s.cluster).OnRequest)
 	s.pubsub.Handle("link", link.New(s, s.pubsub).OnRequest)
 	s.pubsub.Handle("me", me.New().OnRequest)
+	s.pubsub.Handle("history", history.New(s, s.storage).OnRequest)
 
 	// Addresses and things
 	logging.LogTarget("service", "configured node name", nodeName)

--- a/internal/service/history/history.go
+++ b/internal/service/history/history.go
@@ -1,0 +1,71 @@
+/**********************************************************************************
+* Copyright (c) 2009-2020 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package history
+
+import (
+	"encoding/json"
+
+	"github.com/emitter-io/emitter/internal/errors"
+	"github.com/emitter-io/emitter/internal/message"
+	"github.com/emitter-io/emitter/internal/provider/logging"
+	"github.com/emitter-io/emitter/internal/security"
+	"github.com/emitter-io/emitter/internal/service"
+)
+
+// Request represents a historical messages request.
+type Request struct {
+	Key     string `json:"key"`     // The channel key for this request.
+	Channel string `json:"channel"` // The target channel for this request.
+}
+
+// OnRequest handles a request of historical messages.
+func (s *Service) OnRequest(c service.Conn, payload []byte) (service.Response, bool) {
+	var request Request
+	if err := json.Unmarshal(payload, &request); err != nil {
+		return errors.ErrBadRequest, false
+	}
+
+	channel := security.ParseChannel([]byte(request.Channel))
+	if channel.ChannelType == security.ChannelInvalid {
+		return errors.ErrBadRequest, false
+	}
+
+	// Check the authorization and permissions
+	_, key, allowed := s.auth.Authorize(channel, security.AllowLoad)
+	if !allowed {
+		return errors.ErrUnauthorized, false
+	}
+
+	limit := int64(0)
+	if v, ok := channel.Last(); ok {
+		limit = v
+	}
+
+	ssid := message.NewSsid(key.Contract(), channel.Query)
+	t0, t1 := channel.Window() // Get the window
+	msgs, err := s.store.Query(ssid, t0, t1, int(limit))
+	if err != nil {
+		logging.LogError("conn", "query last messages", err)
+		return errors.ErrServerError, false
+	}
+
+	// Range over the messages in the channel and forward them
+	for _, m := range msgs {
+		msg := m // Copy message
+		c.Send(&msg)
+	}
+
+	return nil, true
+}

--- a/internal/service/history/service.go
+++ b/internal/service/history/service.go
@@ -1,0 +1,42 @@
+/**********************************************************************************
+* Copyright (c) 2009-2020 Misakai Ltd.
+* This program is free software: you can redistribute it and/or modify it under the
+* terms of the GNU Affero General Public License as published by the  Free Software
+* Foundation, either version 3 of the License, or(at your option) any later version.
+*
+* This program is distributed  in the hope that it  will be useful, but WITHOUT ANY
+* WARRANTY;  without even  the implied warranty of MERCHANTABILITY or FITNESS FOR A
+* PARTICULAR PURPOSE.  See the GNU Affero General Public License  for  more details.
+*
+* You should have  received a copy  of the  GNU Affero General Public License along
+* with this program. If not, see<http://www.gnu.org/licenses/>.
+************************************************************************************/
+
+package history
+
+import (
+	"github.com/emitter-io/emitter/internal/provider/storage"
+	"github.com/emitter-io/emitter/internal/security/hash"
+	"github.com/emitter-io/emitter/internal/service"
+)
+
+// Service represents a history service.
+type Service struct {
+	auth     service.Authorizer         // The authorizer to use.
+	store    storage.Storage            // The storage provider to use.
+	handlers map[uint32]service.Handler // The emitter request handlers.
+}
+
+// New creates a new publisher service.
+func New(auth service.Authorizer, store storage.Storage) *Service {
+	return &Service{
+		auth:     auth,
+		store:    store,
+		handlers: make(map[uint32]service.Handler),
+	}
+}
+
+// Handle adds a handler for an "emitter/..." request
+func (s *Service) Handle(request string, handler service.Handler) {
+	s.handlers[hash.OfString(request)] = handler
+}

--- a/internal/service/pubsub/subscribe.go
+++ b/internal/service/pubsub/subscribe.go
@@ -16,6 +16,7 @@ package pubsub
 
 import (
 	"bytes"
+
 	"github.com/emitter-io/emitter/internal/errors"
 	"github.com/emitter-io/emitter/internal/event"
 	"github.com/emitter-io/emitter/internal/message"


### PR DESCRIPTION
The message history of a channel can be retrieved when subscribing.
This API allows requesting the history independently of the
subscription request.

The code essentially comes from the the subcription handler.

TODO:
- Write tests.
- Actually test to see if it even works, this is just a draft.