### PR TITLE
internal/broker: fix clobbered context

### DIFF
--- a/internal/broker/service.go
+++ b/internal/broker/service.go
@@ -78,7 +78,7 @@ type Service struct {
 
 // NewService creates a new service.
 func NewService(ctx context.Context, cfg *config.Config) (s *Service, err error) {
-	ctx, cancel := context.WithCancel(context.Background())
+	ctx, cancel := context.WithCancel(ctx)
 	var trie *message.Trie
 	if "mqtt" == cfg.Matcher {
 		trie = message.NewTrieMQTT()


### PR DESCRIPTION
This fixes the spot in `internal/broker` where `NewService()` required a `context.Context` as its argument and then immediately clobbered it with `context.Background()`.