### PR TITLE
[IMP] Adds a Status (200) field to Me and Presence response for consistency

### DIFF
--- a/internal/service/me/me.go
+++ b/internal/service/me/me.go
@@ -45,7 +45,8 @@ func (s *Service) OnRequest(c service.Conn, payload []byte) (service.Response, b
 	}
 
 	return &Response{
-		ID:    c.ID(),
-		Links: links,
+		Status: 200,
+		ID:     c.ID(),
+		Links:  links,
 	}, true
 }

--- a/internal/service/me/requests.go
+++ b/internal/service/me/requests.go
@@ -17,6 +17,7 @@ package me
 // Response represents a response for the 'me' request.
 type Response struct {
 	Request uint16            `json:"req,omitempty"`   // The corresponding request ID.
+	Status  int               `json:"status"`          // The status of the response
 	ID      string            `json:"id"`              // The private ID of the connection.
 	Links   map[string]string `json:"links,omitempty"` // The set of pre-defined channels.
 }

--- a/internal/service/presence/presence.go
+++ b/internal/service/presence/presence.go
@@ -90,6 +90,7 @@ func (s *Service) OnRequest(c service.Conn, payload []byte) (service.Response, b
 		// Gather local & cluster presence
 		who = append(who, s.getAllPresence(ssid)...)
 		return &Response{
+			Status:  200,
 			Time:    now,
 			Event:   EventTypeStatus,
 			Channel: msg.Channel,
@@ -97,7 +98,9 @@ func (s *Service) OnRequest(c service.Conn, payload []byte) (service.Response, b
 		}, true
 	}
 
-	return nil, true
+	return &Response{
+		Status: 200,
+	}, true
 }
 
 // OnHTTP occurs when a new HTTP presence request is received.

--- a/internal/service/presence/requests.go
+++ b/internal/service/presence/requests.go
@@ -45,6 +45,7 @@ const (
 // Response represents a state notification.
 type Response struct {
 	Request uint16    `json:"req,omitempty"` // The corresponding request ID.
+	Status  int       `json:"status"`        // The status of the response
 	Time    int64     `json:"time"`          // The UNIX timestamp.
 	Event   EventType `json:"event"`         // The event, must be "status", "subscribe" or "unsubscribe".
 	Channel string    `json:"channel"`       // The target channel for the notification.


### PR DESCRIPTION
@kelindar Note that we seem to only ever return a status when everything went fine and it's a 200. Was this the intention?

NOTE that we also send a Response with 200 in the case of a response to
a Presence request with the status flag set to false. In this case, we
don't gather the presence statuses on the brokers, but we need to send
an empty response instead of just nil. This will allow for an RPC call
on Presence. See the SDKs (Go in particular).